### PR TITLE
Fix bottom resource bar overlay blocking and improve Mars panning

### DIFF
--- a/frontend/src/components/game/controls/PanControls.tsx
+++ b/frontend/src/components/game/controls/PanControls.tsx
@@ -14,6 +14,10 @@ export function PanControls() {
       isPointerDown.current = true;
       previousPointer.current = { x: event.clientX, y: event.clientY };
       gl.domElement.style.cursor = "grabbing";
+
+      // Add document-level listeners for global pointer tracking
+      document.addEventListener("pointermove", handlePointerMove);
+      document.addEventListener("pointerup", handlePointerUp);
     };
 
     const handlePointerMove = (event: PointerEvent) => {
@@ -43,6 +47,10 @@ export function PanControls() {
     const handlePointerUp = () => {
       isPointerDown.current = false;
       gl.domElement.style.cursor = "grab";
+
+      // Remove document-level listeners when drag ends
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
     };
 
     const handleWheel = (event: WheelEvent) => {
@@ -76,19 +84,17 @@ export function PanControls() {
     // Set initial cursor
     domElement.style.cursor = "grab";
 
-    // Add event listeners
+    // Add event listeners - only pointerdown on canvas, others handled dynamically
     domElement.addEventListener("pointerdown", handlePointerDown);
-    domElement.addEventListener("pointermove", handlePointerMove);
-    domElement.addEventListener("pointerup", handlePointerUp);
-    domElement.addEventListener("pointerleave", handlePointerUp);
     domElement.addEventListener("wheel", handleWheel, { passive: false });
 
     return () => {
       domElement.removeEventListener("pointerdown", handlePointerDown);
-      domElement.removeEventListener("pointermove", handlePointerMove);
-      domElement.removeEventListener("pointerup", handlePointerUp);
-      domElement.removeEventListener("pointerleave", handlePointerUp);
       domElement.removeEventListener("wheel", handleWheel);
+
+      // Clean up any remaining document listeners in case component unmounts during drag
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
     };
   }, [camera, gl]);
 

--- a/frontend/src/components/layout/main/GameLayout.tsx
+++ b/frontend/src/components/layout/main/GameLayout.tsx
@@ -4,7 +4,6 @@ import TopMenuBar from "../panels/TopMenuBar.tsx";
 import RightSidebar from "../panels/RightSidebar.tsx";
 import MainContentDisplay from "../../ui/display/MainContentDisplay.tsx";
 import BottomResourceBar from "../../ui/overlay/BottomResourceBar.tsx";
-import CardsHandOverlay from "../../ui/overlay/CardsHandOverlay.tsx";
 import PlayerOverlay from "../../ui/overlay/PlayerOverlay.tsx";
 import { MainContentProvider } from "../../../contexts/MainContentContext.tsx";
 import {
@@ -29,7 +28,7 @@ interface GameLayoutProps {
 const GameLayout: React.FC<GameLayoutProps> = ({
   gameState,
   currentPlayer,
-  isAnyModalOpen = false,
+  isAnyModalOpen: _isAnyModalOpen = false,
   isLobbyPhase = false,
   onOpenCardEffectsModal,
   onOpenActionsModal,
@@ -102,8 +101,6 @@ const GameLayout: React.FC<GameLayoutProps> = ({
               onOpenTagsModal={onOpenTagsModal}
               onOpenVictoryPointsModal={onOpenVictoryPointsModal}
             />
-
-            <CardsHandOverlay hideWhenModalOpen={isAnyModalOpen} />
           </>
         )}
       </div>

--- a/frontend/src/components/ui/overlay/CardFanOverlay.tsx
+++ b/frontend/src/components/ui/overlay/CardFanOverlay.tsx
@@ -407,7 +407,7 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
 
         .card-hand-container {
           position: absolute;
-          bottom: 0px;
+          bottom: 48px; /* Position above BottomResourceBar (48px height) */
           left: 50%;
           transform: translateX(-50%);
           width: 100%;

--- a/frontend/src/components/ui/overlay/CardsHandOverlay.tsx
+++ b/frontend/src/components/ui/overlay/CardsHandOverlay.tsx
@@ -507,7 +507,7 @@ const CardsHandOverlay: React.FC<CardsHandOverlayProps> = ({
 
         .card-hand-container {
           position: absolute;
-          bottom: 0px;
+          bottom: 48px; /* Position above BottomResourceBar (48px height) */
           left: 50%;
           transform: translateX(-50%);
           width: 100%;


### PR DESCRIPTION
## Summary
This PR fixes critical UI interaction issues that were preventing users from clicking on bottom resource bar components and improves the Mars rotation experience.

## Issues Fixed
- ✅ **Bottom resource bar components now clickable** - Removed legacy `CardsHandOverlay` that was blocking clicks on Credits, Steel, Titanium, Plants, Energy, Heat, and action buttons (Tags, VP, Effects, etc.)
- ✅ **Enhanced Mars panning experience** - Mars rotation no longer accidentally stops when cursor moves outside the canvas or over other HTML elements
- ✅ **Code quality improvements** - Fixed linting warnings and formatted all code

## Root Cause Analysis
The issue was caused by two overlapping card overlay components:
1. **Legacy `CardsHandOverlay`** (with mock Hearthstone cards) - rendered in GameLayout, blocking bottom bar
2. **Active `CardFanOverlay`** (with real game cards) - rendered in GameInterface, working correctly

The legacy component had a `.card-hand-container` positioned at `bottom: 0px` with `width: 100%` and `pointer-events: auto`, which was directly overlapping the `BottomResourceBar`.

## Changes Made

### 🔧 UI Fixes
- **Removed** legacy `CardsHandOverlay` from `GameLayout.tsx` (was redundant and blocking clicks)
- **Updated** `CardFanOverlay` positioning to `bottom: 48px` to ensure proper clearance above bottom bar
- **Maintained** real game card functionality through `CardFanOverlay` in `GameInterface`

### 🎮 Mars Panning Improvements  
- **Enhanced** `PanControls.tsx` to use document-level event listeners during drag operations
- **Prevented** accidental release when mouse moves outside canvas or over other UI elements
- **Improved** user experience for Mars rotation with seamless dragging

### 🧹 Code Quality
- **Fixed** unused parameter linting warning in `GameLayout`
- **Formatted** all code with `make format` 
- **Verified** no linting errors or warnings with `make lint`

## Testing
- [x] Bottom resource bar components are fully clickable (Credits, Steel, Titanium, Plants, Energy, Heat)
- [x] Action buttons work correctly (Tags, VP, Effects, Actions, Played Cards)
- [x] Mars panning is smooth and doesn't release when cursor leaves canvas
- [x] Card hand functionality still works correctly through CardFanOverlay
- [x] No console errors or warnings
- [x] All linting and formatting checks pass

## Technical Details
- **Removed component**: `CardsHandOverlay` (contained mock data, not real game cards)
- **Active component**: `CardFanOverlay` (handles actual player cards from game state)
- **Event handling**: Moved from canvas-only to document-level listeners during Mars drag operations
- **Positioning**: Updated card overlay positioning to respect bottom bar boundaries

🤖 Generated with [Claude Code](https://claude.ai/code)