### PR TITLE
feat: Add support for manual action choices

### DIFF
--- a/frontend/src/components/ui/popover/ChoiceSelectionPopover.tsx
+++ b/frontend/src/components/ui/popover/ChoiceSelectionPopover.tsx
@@ -17,6 +17,7 @@ interface ChoiceSelectionPopoverProps {
   onChoiceSelect: (choiceIndex: number) => void;
   onCancel: () => void;
   isVisible: boolean;
+  isAction?: boolean; // True if this is for an action, false/undefined if for card play
 }
 
 const ChoiceSelectionPopover: React.FC<ChoiceSelectionPopoverProps> = ({
@@ -25,6 +26,7 @@ const ChoiceSelectionPopover: React.FC<ChoiceSelectionPopoverProps> = ({
   onChoiceSelect,
   onCancel,
   isVisible,
+  isAction = false,
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [isClosing, setIsClosing] = useState(false);
@@ -117,7 +119,7 @@ const ChoiceSelectionPopover: React.FC<ChoiceSelectionPopoverProps> = ({
         {/* Header */}
         <div className="py-[15px] px-5 bg-black/40 border-b border-b-space-blue-500/60">
           <h3 className="m-0 font-orbitron text-white text-base font-bold text-shadow-glow">
-            Choose One Effect
+            {isAction ? "Choose Action Effect" : "Choose One Effect"}
           </h3>
           <div className="text-white/60 text-xs text-shadow-glow mt-1">
             {card.name}

--- a/frontend/src/types/generated/api-types.ts
+++ b/frontend/src/types/generated/api-types.ts
@@ -199,6 +199,8 @@ export const AdminCommandTypeSetGlobalParams: AdminCommandType =
   "set-global-params";
 export const AdminCommandTypeStartTileSelection: AdminCommandType =
   "start-tile-selection";
+export const AdminCommandTypeSetCurrentTurn: AdminCommandType =
+  "set-current-turn";
 /**
  * AdminCommandRequest contains the admin command data
  */


### PR DESCRIPTION
## Summary

Implements proper distinction between auto-triggered choices (at card play time) and manual-triggered choices (at action execution time).

Previously, the system required choice selection for ANY card behavior with choices, regardless of trigger type. This caused issues where cards with manual-triggered actions (that have choices) couldn't be played because the system expected a choice index at play time.

## Backend Changes

### `backend/internal/service/card_service.go`

**OnPlayCard validation:**
- Now only checks for choices in **auto-triggered** behaviors
- Manual-triggered behaviors (actions) have their choices handled separately
- Updated error messages to be more specific about auto-triggered choices

**OnPlayCardAction processing:**
- Added `choiceIndex` parameter support to action input/output validation
- `validateActionInputs`: Aggregates behavior inputs + choice inputs
- `applyActionInputs`: Applies aggregated inputs (deducts resources)
- `applyActionOutputs`: Applies aggregated outputs (grants resources/production)

## Frontend Changes

### `frontend/src/components/layout/main/GameInterface.tsx`

**Card play logic:**
- `handlePlayCard`: Only checks for choices in auto-triggered behaviors
- Added action choice selection state (`showActionChoiceSelection`, `actionPendingChoice`)

**Action execution logic:**
- `handleActionSelect`: Checks if action has choices and shows popover if needed
- `handleActionChoiceSelect`: Executes action with selected choice
- `handleActionChoiceCancel`: Cancels action choice selection
- Added second `ChoiceSelectionPopover` instance specifically for action choices

### `frontend/src/components/ui/popover/ChoiceSelectionPopover.tsx`

- Added optional `isAction` prop to distinguish context
- Updated header text: "Choose Action Effect" for actions vs "Choose One Effect" for card play

## Test Plan

### Manual Testing Scenarios

1. **Card with auto-triggered choices:**
   - Play a card with auto-triggered choice behavior
   - ✅ Choice popover should appear at play time
   - ✅ Card should be played with selected choice

2. **Card with manual-triggered choices (action):**
   - Play a card with manual-triggered choice behavior
   - ✅ Card should play immediately without choice popover
   - ✅ Action appears in actions list
   - ✅ When executing the action, choice popover should appear
   - ✅ Action should execute with selected choice

3. **Card with both auto and manual choices:**
   - Play a card with both types
   - ✅ Auto choice popover at play time
   - ✅ Manual choice popover at action time

### Automated Tests

- ✅ All backend tests pass (`make test`)
- ✅ No linting errors (`make lint`)
- ✅ TypeScript type checking passes
- ✅ Code formatted (`make format`)

## Breaking Changes

None - this is a bug fix that makes the system work correctly according to the trigger type semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)