### PR TITLE
fix: use relative URLs for API and WebSocket in production

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -32,7 +32,7 @@ server {
     }
 
     # WebSocket proxy for real-time game state
-    location /socket.io/ {
+    location /ws {
         proxy_pass http://backend:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -10,10 +10,17 @@ import {
   ListCardsResponse,
 } from "../types/generated/api-types.ts";
 
+function getDefaultApiUrl(): string {
+  if (typeof window !== "undefined" && window.location.hostname !== "localhost") {
+    return "/api/v1";
+  }
+  return "http://localhost:3001/api/v1";
+}
+
 export class ApiService {
   private baseUrl: string;
 
-  constructor(baseUrl: string = "http://localhost:3001/api/v1") {
+  constructor(baseUrl: string = getDefaultApiUrl()) {
     this.baseUrl = baseUrl;
   }
 

--- a/frontend/src/services/webSocketService.ts
+++ b/frontend/src/services/webSocketService.ts
@@ -54,8 +54,15 @@ export class WebSocketService {
   private pendingConnection: Promise<void> | null = null;
   private shouldReconnect = true;
 
-  constructor(url: string = "ws://localhost:3001/ws") {
-    this.url = url;
+  constructor(url?: string) {
+    if (url) {
+      this.url = url;
+    } else if (typeof window !== "undefined" && window.location.hostname !== "localhost") {
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      this.url = `${protocol}//${window.location.host}/ws`;
+    } else {
+      this.url = "ws://localhost:3001/ws";
+    }
   }
 
   connect(): Promise<void> {


### PR DESCRIPTION
## Summary
- Frontend was hardcoded to `localhost:3001`, causing CORS errors in production
- ApiService now uses `/api/v1` when not on localhost
- WebSocketService uses `wss://host/ws` in production
- Fixed nginx WebSocket proxy path from `/socket.io/` to `/ws`

## Test plan
- [ ] Deploy to Pi and verify game creation works
- [ ] Verify WebSocket connection establishes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)