### PR TITLE
fix: close production modal after card selection

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -381,6 +381,7 @@ export default function GameInterface() {
     // Check if current player has production phase data
     const hasProductionData =
       currentPlayer.productionPhase &&
+      !currentPlayer.productionPhase.selectionComplete &&
       currentPlayer.productionPhase.availableCards &&
       currentPlayer.productionPhase.availableCards.length >= 0;
 


### PR DESCRIPTION
## Summary
- Check `selectionComplete` flag before showing the production phase modal
- Fixes modal staying open after buying cards during production phase
- Fixes modal reappearing on page refresh after selection was already completed

## Test plan
- [ ] Start a multiplayer game and advance to production phase
- [ ] Buy cards as one player → modal should close after confirmation
- [ ] Refresh the page → production modal should NOT reappear
- [ ] Verify other player who hasn't bought cards still sees the modal
- [ ] Verify game transitions to action phase normally when all players complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)