### PR TITLE
Fix card fan overlapping bottom resource bar

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -19,13 +19,14 @@ import TabConflictOverlay from "../../ui/overlay/TabConflictOverlay.tsx";
 import StartingCardSelectionOverlay from "../../ui/overlay/StartingCardSelectionOverlay.tsx";
 import PendingCardSelectionOverlay from "../../ui/overlay/PendingCardSelectionOverlay.tsx";
 import CardDrawSelectionOverlay from "../../ui/overlay/CardDrawSelectionOverlay.tsx";
-import CardFanOverlay from "../../ui/overlay/CardFanOverlay.tsx";
 import LoadingOverlay from "../../game/view/LoadingOverlay.tsx";
 import MainMenuSettingsButton from "../../ui/buttons/MainMenuSettingsButton.tsx";
 import GameMenuButton from "../../ui/buttons/GameMenuButton.tsx";
 import GameMenuModal from "../../ui/overlay/GameMenuModal.tsx";
 import SpaceBackground from "../../3d/SpaceBackground.tsx";
-import EndGameOverlay, { TileVPIndicator } from "../../ui/overlay/EndGameOverlay.tsx";
+import EndGameOverlay, {
+  TileVPIndicator,
+} from "../../ui/overlay/EndGameOverlay.tsx";
 import { TileHighlightMode } from "../../game/board/Tile.tsx";
 import ChoiceSelectionPopover from "../../ui/popover/ChoiceSelectionPopover.tsx";
 import CardStorageSelectionPopover from "../../ui/popover/CardStorageSelectionPopover.tsx";
@@ -39,7 +40,11 @@ import { useSpaceBackground } from "@/contexts/SpaceBackgroundContext.tsx";
 import { useNotifications } from "@/contexts/NotificationContext.tsx";
 import { skyboxCache } from "@/services/SkyboxCache.ts";
 import { audioService } from "@/services/audioService.ts";
-import { clearGameSession, getGameSession, saveGameSession } from "@/utils/sessionStorage.ts";
+import {
+  clearGameSession,
+  getGameSession,
+  saveGameSession,
+} from "@/utils/sessionStorage.ts";
 import {
   CardDto,
   CardPaymentDto,
@@ -59,14 +64,28 @@ import {
   StateDiffDto,
   TriggeredEffectDto,
 } from "@/types/generated/api-types.ts";
-import { shouldShowPaymentModal, createDefaultPayment } from "@/utils/paymentUtils.ts";
+import {
+  shouldShowPaymentModal,
+  createDefaultPayment,
+} from "@/utils/paymentUtils.ts";
 import { getPlayerColor } from "@/utils/playerColors.ts";
 import { deepClone, findChangedPaths } from "@/utils/deepCompare.ts";
 import { StandardProject } from "@/types/cards.tsx";
 
-type TransitionPhase = "idle" | "lobby" | "loading" | "fadeOutLobby" | "animateUI" | "complete";
+type TransitionPhase =
+  | "idle"
+  | "lobby"
+  | "loading"
+  | "fadeOutLobby"
+  | "animateUI"
+  | "complete";
 
-type LoadingPhase = "checking" | "selecting" | "joining" | "connecting" | "ready";
+type LoadingPhase =
+  | "checking"
+  | "selecting"
+  | "joining"
+  | "connecting"
+  | "ready";
 
 export default function GameInterface() {
   const location = useLocation();
@@ -82,14 +101,19 @@ export default function GameInterface() {
   const { showNotification } = useNotifications();
   const [game, setGame] = useState<GameDto | null>(null);
   const [isConnected, setIsConnected] = useState(false);
-  const [transitionPhase, setTransitionPhase] = useState<TransitionPhase>("idle");
+  const [transitionPhase, setTransitionPhase] =
+    useState<TransitionPhase>("idle");
   const wasInLobby = useRef(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
-  const [reconnectionStep, setReconnectionStep] = useState<"game" | "environment" | null>(null);
+  const [reconnectionStep, setReconnectionStep] = useState<
+    "game" | "environment" | null
+  >(null);
   const [currentPlayer, setCurrentPlayer] = useState<PlayerDto | null>(null);
   const [playerId, setPlayerId] = useState<string | null>(null); // Track player ID separately
   const [loadingPhase, setLoadingPhase] = useState<LoadingPhase>("checking");
-  const [gameForSelection, setGameForSelection] = useState<GameDto | null>(null);
+  const [gameForSelection, setGameForSelection] = useState<GameDto | null>(
+    null,
+  );
   const [_showCorporationModal, setShowCorporationModal] = useState(false);
   const [corporationData, setCorporationData] = useState<CardDto | null>(null);
 
@@ -99,7 +123,9 @@ export default function GameInterface() {
   const [showActionsModal, setShowActionsModal] = useState(false);
   const [showDebugDropdown, setShowDebugDropdown] = useState(false);
   const [showPerformanceWindow, setShowPerformanceWindow] = useState(false);
-  const [tilePlacerPlayerId, setTilePlacerPlayerId] = useState<string | null>(null);
+  const [tilePlacerPlayerId, setTilePlacerPlayerId] = useState<string | null>(
+    null,
+  );
   const [spectatePlayerId, setSpectatePlayerId] = useState<string | null>(null);
 
   // Set corporation data directly from player (backend now sends full CardDto)
@@ -112,9 +138,11 @@ export default function GameInterface() {
   }, [currentPlayer?.corporation]);
 
   // Production phase modal state
-  const [showProductionPhaseModal, setShowProductionPhaseModal] = useState(false);
+  const [showProductionPhaseModal, setShowProductionPhaseModal] =
+    useState(false);
   const [isProductionModalHidden, setIsProductionModalHidden] = useState(false);
-  const [openProductionToCardSelection, setOpenProductionToCardSelection] = useState(false);
+  const [openProductionToCardSelection, setOpenProductionToCardSelection] =
+    useState(false);
   const isInitialMount = useRef(true);
 
   // Card selection state
@@ -122,25 +150,31 @@ export default function GameInterface() {
   const [cardDetails, setCardDetails] = useState<CardDto[]>([]);
 
   // Pending card selection state (for sell patents, etc.)
-  const [showPendingCardSelection, setShowPendingCardSelection] = useState(false);
+  const [showPendingCardSelection, setShowPendingCardSelection] =
+    useState(false);
 
   // Card draw selection state (for card-draw/peek/take/buy effects)
   const [showCardDrawSelection, setShowCardDrawSelection] = useState(false);
 
   // End game tile highlighting state
-  const [tileHighlightMode, setTileHighlightMode] = useState<TileHighlightMode>(null);
+  const [tileHighlightMode, setTileHighlightMode] =
+    useState<TileHighlightMode>(null);
 
   // End game VP indicators state
   const [vpIndicators, setVPIndicators] = useState<TileVPIndicator[]>([]);
 
   // Choice selection state (for card play)
   const [showChoiceSelection, setShowChoiceSelection] = useState(false);
-  const [cardPendingChoice, setCardPendingChoice] = useState<CardDto | null>(null);
+  const [cardPendingChoice, setCardPendingChoice] = useState<CardDto | null>(
+    null,
+  );
   const [pendingCardBehaviorIndex, setPendingCardBehaviorIndex] = useState(0);
 
   // Action choice selection state (for playing actions with choices)
-  const [showActionChoiceSelection, setShowActionChoiceSelection] = useState(false);
-  const [actionPendingChoice, setActionPendingChoice] = useState<PlayerActionDto | null>(null);
+  const [showActionChoiceSelection, setShowActionChoiceSelection] =
+    useState(false);
+  const [actionPendingChoice, setActionPendingChoice] =
+    useState<PlayerActionDto | null>(null);
 
   // Payment selection state
   const [showPaymentSelection, setShowPaymentSelection] = useState(false);
@@ -150,7 +184,8 @@ export default function GameInterface() {
   } | null>(null);
 
   // Card storage selection state
-  const [showCardStorageSelection, setShowCardStorageSelection] = useState(false);
+  const [showCardStorageSelection, setShowCardStorageSelection] =
+    useState(false);
   const [pendingCardStorage, setPendingCardStorage] = useState<{
     cardId: string;
     payment: CardPaymentDto;
@@ -160,7 +195,8 @@ export default function GameInterface() {
   } | null>(null);
 
   // Action storage selection state
-  const [showActionStorageSelection, setShowActionStorageSelection] = useState(false);
+  const [showActionStorageSelection, setShowActionStorageSelection] =
+    useState(false);
   const [pendingActionStorage, setPendingActionStorage] = useState<{
     cardId: string;
     behaviorIndex: number;
@@ -170,7 +206,8 @@ export default function GameInterface() {
   } | null>(null);
 
   // Target player selection state (for any-player resource/production removal)
-  const [showTargetPlayerSelection, setShowTargetPlayerSelection] = useState(false);
+  const [showTargetPlayerSelection, setShowTargetPlayerSelection] =
+    useState(false);
   const [pendingTargetPlayer, setPendingTargetPlayer] = useState<{
     cardId: string;
     payment: CardPaymentDto;
@@ -182,7 +219,8 @@ export default function GameInterface() {
   } | null>(null);
 
   // Action target player selection state
-  const [showActionTargetPlayerSelection, setShowActionTargetPlayerSelection] = useState(false);
+  const [showActionTargetPlayerSelection, setShowActionTargetPlayerSelection] =
+    useState(false);
   const [pendingActionTargetPlayer, setPendingActionTargetPlayer] = useState<{
     cardId: string;
     behaviorIndex: number;
@@ -194,7 +232,8 @@ export default function GameInterface() {
   } | null>(null);
 
   // Card resource selection state (for steal-from-any-card inputs like Predators/Ants)
-  const [showCardResourceSelection, setShowCardResourceSelection] = useState(false);
+  const [showCardResourceSelection, setShowCardResourceSelection] =
+    useState(false);
   const [pendingCardResourceInput, setPendingCardResourceInput] = useState<{
     cardId: string;
     behaviorIndex: number;
@@ -219,9 +258,13 @@ export default function GameInterface() {
   const [changedPaths, setChangedPaths] = useState<Set<string>>(new Set());
 
   // Triggered effects notifications
-  const [triggeredEffects, setTriggeredEffects] = useState<TriggeredEffectDto[]>([]);
+  const [triggeredEffects, setTriggeredEffects] = useState<
+    TriggeredEffectDto[]
+  >([]);
 
-  const [isSkyboxReady, setIsSkyboxReady] = useState(() => skyboxCache.isReady());
+  const [isSkyboxReady, setIsSkyboxReady] = useState(() =>
+    skyboxCache.isReady(),
+  );
   const [isGpuReady, setIsGpuReady] = useState(false);
   const [overlayVisible, setOverlayVisible] = useState(true);
   const { isLoaded: isSpaceBgLoaded } = useSpaceBackground();
@@ -262,21 +305,33 @@ export default function GameInterface() {
         // Play temperature increase sound when temperature goes up
         const prevTemp = previousGameRef.current.globalParameters?.temperature;
         const newTemp = updatedGame.globalParameters?.temperature;
-        if (prevTemp !== undefined && newTemp !== undefined && newTemp > prevTemp) {
+        if (
+          prevTemp !== undefined &&
+          newTemp !== undefined &&
+          newTemp > prevTemp
+        ) {
           void playTemperatureSound();
         }
 
         // Play water placement sound when ocean count increases
         const prevOceans = previousGameRef.current.globalParameters?.oceans;
         const newOceans = updatedGame.globalParameters?.oceans;
-        if (prevOceans !== undefined && newOceans !== undefined && newOceans > prevOceans) {
+        if (
+          prevOceans !== undefined &&
+          newOceans !== undefined &&
+          newOceans > prevOceans
+        ) {
           void playWaterPlacementSound();
         }
 
         // Play oxygen increase sound when oxygen goes up
         const prevOxygen = previousGameRef.current.globalParameters?.oxygen;
         const newOxygen = updatedGame.globalParameters?.oxygen;
-        if (prevOxygen !== undefined && newOxygen !== undefined && newOxygen > prevOxygen) {
+        if (
+          prevOxygen !== undefined &&
+          newOxygen !== undefined &&
+          newOxygen > prevOxygen
+        ) {
           void playOxygenSound();
         }
 
@@ -292,7 +347,10 @@ export default function GameInterface() {
       previousGameRef.current = deepClone(updatedGame);
 
       // Extract triggered effects for notifications (clear after short delay to allow component to process)
-      if (updatedGame.triggeredEffects && updatedGame.triggeredEffects.length > 0) {
+      if (
+        updatedGame.triggeredEffects &&
+        updatedGame.triggeredEffects.length > 0
+      ) {
         setTriggeredEffects(updatedGame.triggeredEffects);
         // Clear after component has processed them
         setTimeout(() => setTriggeredEffects([]), 100);
@@ -318,7 +376,12 @@ export default function GameInterface() {
         setShowCorporationModal(false);
       }
     },
-    [isReconnecting, playTemperatureSound, playWaterPlacementSound, playOxygenSound],
+    [
+      isReconnecting,
+      playTemperatureSound,
+      playWaterPlacementSound,
+      playOxygenSound,
+    ],
   );
 
   const handleLogUpdate = useCallback(
@@ -326,7 +389,8 @@ export default function GameInterface() {
       const ASTEROID_IMPACT_PATTERN = /asteroid|comet|impactor/i;
       const hasAsteroidAction = logs.some(
         (log) =>
-          (log.sourceType === "card_play" || log.sourceType === "standard_project") &&
+          (log.sourceType === "card_play" ||
+            log.sourceType === "standard_project") &&
           ASTEROID_IMPACT_PATTERN.test(log.source),
       );
       if (hasAsteroidAction) {
@@ -354,7 +418,10 @@ export default function GameInterface() {
     clearGameSession();
     globalWebSocketManager.disconnect();
     navigate("/", { replace: true });
-    showNotification({ message: "You were kicked from the game", type: "info" });
+    showNotification({
+      message: "You were kicked from the game",
+      type: "info",
+    });
   }, [navigate, showNotification]);
 
   const handleDisconnect = useCallback(() => {
@@ -426,13 +493,21 @@ export default function GameInterface() {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     }
-  }, [currentPlayer?.productionPhase, game, showProductionPhaseModal, playProductionSound]);
+  }, [
+    currentPlayer?.productionPhase,
+    game,
+    showProductionPhaseModal,
+    playProductionSound,
+  ]);
 
   const handleCardSelection = useCallback(
     async (selectedCardIds: string[], corporationId: string) => {
       try {
         // Send card and corporation selection to server - commits immediately
-        await globalWebSocketManager.selectStartingCard(selectedCardIds, corporationId);
+        await globalWebSocketManager.selectStartingCard(
+          selectedCardIds,
+          corporationId,
+        );
         // Modal will close automatically when backend clears startingSelection
       } catch (error) {
         console.error("Failed to select cards:", error);
@@ -442,30 +517,40 @@ export default function GameInterface() {
   );
 
   // Handle pending card selection (sell patents, etc.)
-  const handlePendingCardSelection = useCallback(async (selectedCardIds: string[]) => {
-    try {
-      await globalWebSocketManager.selectCards(selectedCardIds);
-      // Overlay closes automatically when backend clears pendingCardSelection
-    } catch (error) {
-      console.error("Failed to select cards:", error);
-    }
-  }, []);
+  const handlePendingCardSelection = useCallback(
+    async (selectedCardIds: string[]) => {
+      try {
+        await globalWebSocketManager.selectCards(selectedCardIds);
+        // Overlay closes automatically when backend clears pendingCardSelection
+      } catch (error) {
+        console.error("Failed to select cards:", error);
+      }
+    },
+    [],
+  );
 
   // Handle card draw selection confirmation
-  const handleCardDrawConfirm = useCallback(async (cardsToTake: string[], cardsToBuy: string[]) => {
-    try {
-      await globalWebSocketManager.confirmCardDraw(cardsToTake, cardsToBuy);
-      // Overlay closes automatically when backend clears pendingCardDrawSelection
-    } catch (error) {
-      console.error("Failed to confirm card draw:", error);
-    }
-  }, []);
+  const handleCardDrawConfirm = useCallback(
+    async (cardsToTake: string[], cardsToBuy: string[]) => {
+      try {
+        await globalWebSocketManager.confirmCardDraw(cardsToTake, cardsToBuy);
+        // Overlay closes automatically when backend clears pendingCardDrawSelection
+      } catch (error) {
+        console.error("Failed to confirm card draw:", error);
+      }
+    },
+    [],
+  );
 
   // Helper function to check if outputs need card storage selection
   const needsCardStorageSelection = useCallback(
     (
       outputs: any[] | undefined,
-    ): { resourceType: ResourceType; amount: number; target: string } | null => {
+    ): {
+      resourceType: ResourceType;
+      amount: number;
+      target: string;
+    } | null => {
       if (!outputs) return null;
 
       const storageResources = [
@@ -497,7 +582,11 @@ export default function GameInterface() {
   const needsTargetPlayerSelection = useCallback(
     (
       outputs: any[] | undefined,
-    ): { resourceType: ResourceType; amount: number; isSteal: boolean } | null => {
+    ): {
+      resourceType: ResourceType;
+      amount: number;
+      isSteal: boolean;
+    } | null => {
       if (!outputs) return null;
 
       // Solo mode: no other players, skip target selection
@@ -520,7 +609,8 @@ export default function GameInterface() {
 
       for (const output of outputs) {
         if (
-          (output.target === "any-player" || output.target === "steal-any-player") &&
+          (output.target === "any-player" ||
+            output.target === "steal-any-player") &&
           targetableResources.includes(output.type as ResourceType)
         ) {
           return {
@@ -537,7 +627,9 @@ export default function GameInterface() {
   );
 
   const needsCardResourceInput = useCallback(
-    (inputs: any[] | undefined): { resourceType: ResourceType; amount: number } | null => {
+    (
+      inputs: any[] | undefined,
+    ): { resourceType: ResourceType; amount: number } | null => {
       if (!inputs) return null;
 
       for (const input of inputs) {
@@ -563,14 +655,17 @@ export default function GameInterface() {
       cardForBehaviors?: CardDto,
     ) => {
       // Check if any auto-trigger behavior needs target player selection
-      const card = cardForBehaviors || currentPlayer?.cards.find((c) => c.id === cardId);
+      const card =
+        cardForBehaviors || currentPlayer?.cards.find((c) => c.id === cardId);
       if (card) {
         const autoTriggerBehaviors = card.behaviors?.filter((b) =>
           b.triggers?.some((t) => t.type === "auto"),
         );
         for (const behavior of autoTriggerBehaviors || []) {
           const outputs =
-            choiceIndex !== undefined ? behavior.choices?.[choiceIndex]?.outputs : behavior.outputs;
+            choiceIndex !== undefined
+              ? behavior.choices?.[choiceIndex]?.outputs
+              : behavior.outputs;
           const targetInfo = needsTargetPlayerSelection(outputs);
           if (targetInfo) {
             setPendingTargetPlayer({
@@ -588,7 +683,12 @@ export default function GameInterface() {
         }
       }
 
-      await globalWebSocketManager.playCard(cardId, payment, choiceIndex, cardStorageTarget);
+      await globalWebSocketManager.playCard(
+        cardId,
+        payment,
+        choiceIndex,
+        cardStorageTarget,
+      );
     },
     [currentPlayer?.cards, needsTargetPlayerSelection],
   );
@@ -616,7 +716,10 @@ export default function GameInterface() {
         // Check if any AUTO-triggered behavior has choices
         // Manual-triggered behaviors (actions) will show choices when the action is played
         const behaviorWithChoices = card.behaviors?.findIndex(
-          (b) => b.choices && b.choices.length > 0 && b.triggers?.some((t) => t.type === "auto"),
+          (b) =>
+            b.choices &&
+            b.choices.length > 0 &&
+            b.triggers?.some((t) => t.type === "auto"),
         );
 
         if (
@@ -632,7 +735,11 @@ export default function GameInterface() {
           // No auto-triggered choices, check if we need payment modal
           if (
             currentPlayer &&
-            shouldShowPaymentModal(card, currentPlayer.resources, currentPlayer.paymentSubstitutes)
+            shouldShowPaymentModal(
+              card,
+              currentPlayer.resources,
+              currentPlayer.paymentSubstitutes,
+            )
           ) {
             // Show payment selection modal
             setPendingCardPayment({
@@ -662,7 +769,13 @@ export default function GameInterface() {
             if (storageNeeded) {
               if (storageNeeded.target === "self-card") {
                 // Self-card target: backend uses sourceCardID, no popover needed
-                await finalizePlayCard(cardId, payment, undefined, undefined, card);
+                await finalizePlayCard(
+                  cardId,
+                  payment,
+                  undefined,
+                  undefined,
+                  card,
+                );
               } else {
                 // Show storage selection popover for any-card targets
                 setPendingCardStorage({
@@ -675,7 +788,13 @@ export default function GameInterface() {
               }
             } else {
               // No storage needed, play the card directly
-              await finalizePlayCard(cardId, payment, undefined, undefined, card);
+              await finalizePlayCard(
+                cardId,
+                payment,
+                undefined,
+                undefined,
+                card,
+              );
             }
           }
         }
@@ -721,11 +840,14 @@ export default function GameInterface() {
           const payment = createDefaultPayment(cardPendingChoice.cost);
 
           // Get the selected choice
-          const behavior = cardPendingChoice.behaviors?.[pendingCardBehaviorIndex];
+          const behavior =
+            cardPendingChoice.behaviors?.[pendingCardBehaviorIndex];
           const selectedChoice = behavior?.choices?.[choiceIndex];
 
           // Check if the selected choice outputs need card storage selection
-          const storageInfo = needsCardStorageSelection(selectedChoice?.outputs);
+          const storageInfo = needsCardStorageSelection(
+            selectedChoice?.outputs,
+          );
 
           if (storageInfo) {
             if (storageInfo.target === "self-card") {
@@ -797,7 +919,8 @@ export default function GameInterface() {
         setShowActionChoiceSelection(false);
 
         // Get the selected choice
-        const selectedChoice = actionPendingChoice.behavior.choices?.[choiceIndex];
+        const selectedChoice =
+          actionPendingChoice.behavior.choices?.[choiceIndex];
 
         // Check if the selected choice outputs need card storage selection
         const storageInfo = needsCardStorageSelection(selectedChoice?.outputs);
@@ -805,7 +928,9 @@ export default function GameInterface() {
         if (storageInfo) {
           if (storageInfo.target === "self-card") {
             // Self-card target: check target player needs
-            const targetInfo = needsTargetPlayerSelection(selectedChoice?.outputs);
+            const targetInfo = needsTargetPlayerSelection(
+              selectedChoice?.outputs,
+            );
             if (targetInfo) {
               setPendingActionTargetPlayer({
                 cardId: actionPendingChoice.cardId,
@@ -841,7 +966,9 @@ export default function GameInterface() {
           }
         } else {
           // No card storage needed, check target player needs
-          const targetInfo = needsTargetPlayerSelection(selectedChoice?.outputs);
+          const targetInfo = needsTargetPlayerSelection(
+            selectedChoice?.outputs,
+          );
           if (targetInfo) {
             setPendingActionTargetPlayer({
               cardId: actionPendingChoice.cardId,
@@ -870,7 +997,11 @@ export default function GameInterface() {
         setActionPendingChoice(null);
       }
     },
-    [actionPendingChoice, needsCardStorageSelection, needsTargetPlayerSelection],
+    [
+      actionPendingChoice,
+      needsCardStorageSelection,
+      needsTargetPlayerSelection,
+    ],
   );
 
   const handleActionChoiceCancel = useCallback(() => {
@@ -888,7 +1019,10 @@ export default function GameInterface() {
 
         // Check if card storage selection is still needed
         const autoTriggerBehaviors = pendingCardPayment.card.behaviors?.filter(
-          (b) => b.triggers && b.triggers.length > 0 && b.triggers.some((t) => t.type === "auto"),
+          (b) =>
+            b.triggers &&
+            b.triggers.length > 0 &&
+            b.triggers.some((t) => t.type === "auto"),
         );
 
         let storageNeeded: {
@@ -939,7 +1073,12 @@ export default function GameInterface() {
         setPendingCardPayment(null);
       }
     },
-    [pendingCardPayment, currentPlayer, needsCardStorageSelection, finalizePlayCard],
+    [
+      pendingCardPayment,
+      currentPlayer,
+      needsCardStorageSelection,
+      finalizePlayCard,
+    ],
   );
 
   const handlePaymentCancel = useCallback(() => {
@@ -955,12 +1094,17 @@ export default function GameInterface() {
         setShowCardStorageSelection(false);
 
         // Find the card to check for target player needs
-        const card = currentPlayer?.cards.find((c) => c.id === pendingCardStorage.cardId);
+        const card = currentPlayer?.cards.find(
+          (c) => c.id === pendingCardStorage.cardId,
+        );
         const autoTriggerBehaviors = card?.behaviors?.filter((b) =>
           b.triggers?.some((t) => t.type === "auto"),
         );
-        let targetInfo: { resourceType: ResourceType; amount: number; isSteal: boolean } | null =
-          null;
+        let targetInfo: {
+          resourceType: ResourceType;
+          amount: number;
+          isSteal: boolean;
+        } | null = null;
         for (const behavior of autoTriggerBehaviors || []) {
           const outputs =
             pendingCardStorage.choiceIndex !== undefined
@@ -1025,7 +1169,8 @@ export default function GameInterface() {
         );
         const outputs =
           pendingActionStorage.choiceIndex !== undefined
-            ? action?.behavior.choices?.[pendingActionStorage.choiceIndex]?.outputs
+            ? action?.behavior.choices?.[pendingActionStorage.choiceIndex]
+                ?.outputs
             : action?.behavior.outputs;
         const targetInfo = needsTargetPlayerSelection(outputs);
 
@@ -1163,7 +1308,9 @@ export default function GameInterface() {
     try {
       const savedGameData = getGameSession();
       if (!savedGameData) {
-        console.log("No saved game data for reconnection, returning to landing page");
+        console.log(
+          "No saved game data for reconnection, returning to landing page",
+        );
         clearGameSession();
         navigate("/", { replace: true });
         return;
@@ -1215,7 +1362,9 @@ export default function GameInterface() {
       setReconnectionStep(null);
       // Don't navigate away - let user try manual reconnection
       // or they can manually navigate to home if needed
-      console.error("Failed to reconnect to game. Please check your connection and try again.");
+      console.error(
+        "Failed to reconnect to game. Please check your connection and try again.",
+      );
     }
   }, [navigate]);
 
@@ -1232,7 +1381,10 @@ export default function GameInterface() {
     globalWebSocketManager.on("player-kicked", handlePlayerKicked);
     globalWebSocketManager.on("error", handleError);
     globalWebSocketManager.on("disconnect", handleDisconnect);
-    globalWebSocketManager.on("max-reconnects-reached", handleMaxReconnectsReached);
+    globalWebSocketManager.on(
+      "max-reconnects-reached",
+      handleMaxReconnectsReached,
+    );
 
     isWebSocketInitialized.current = true;
 
@@ -1240,11 +1392,17 @@ export default function GameInterface() {
       globalWebSocketManager.off("game-updated", handleGameUpdated);
       globalWebSocketManager.off("full-state", handleFullState);
       globalWebSocketManager.off("log-update", handleLogUpdate);
-      globalWebSocketManager.off("player-disconnected", handlePlayerDisconnected);
+      globalWebSocketManager.off(
+        "player-disconnected",
+        handlePlayerDisconnected,
+      );
       globalWebSocketManager.off("player-kicked", handlePlayerKicked);
       globalWebSocketManager.off("error", handleError);
       globalWebSocketManager.off("disconnect", handleDisconnect);
-      globalWebSocketManager.off("max-reconnects-reached", handleMaxReconnectsReached);
+      globalWebSocketManager.off(
+        "max-reconnects-reached",
+        handleMaxReconnectsReached,
+      );
       isWebSocketInitialized.current = false;
     };
   }, [
@@ -1277,8 +1435,11 @@ export default function GameInterface() {
 
         if (cardResourceInfo) {
           // Determine cardStorageTarget for the output side
-          const storageInfo = needsCardStorageSelection(action.behavior.outputs);
-          const cardStorageTarget = storageInfo?.target === "self-card" ? action.cardId : undefined;
+          const storageInfo = needsCardStorageSelection(
+            action.behavior.outputs,
+          );
+          const cardStorageTarget =
+            storageInfo?.target === "self-card" ? action.cardId : undefined;
 
           setPendingCardResourceInput({
             cardId: action.cardId,
@@ -1290,13 +1451,17 @@ export default function GameInterface() {
           setShowCardResourceSelection(true);
         } else {
           // No card resource input, check if action outputs need card storage selection
-          const storageInfo = needsCardStorageSelection(action.behavior.outputs);
+          const storageInfo = needsCardStorageSelection(
+            action.behavior.outputs,
+          );
 
           if (storageInfo) {
             if (storageInfo.target === "self-card") {
               // Self-card target: skip popover and send directly with the source card as target
               // Check target player needs
-              const targetInfo = needsTargetPlayerSelection(action.behavior.outputs);
+              const targetInfo = needsTargetPlayerSelection(
+                action.behavior.outputs,
+              );
               if (targetInfo) {
                 setPendingActionTargetPlayer({
                   cardId: action.cardId,
@@ -1327,7 +1492,9 @@ export default function GameInterface() {
             }
           } else {
             // No card storage needed, check target player needs
-            const targetInfo = needsTargetPlayerSelection(action.behavior.outputs);
+            const targetInfo = needsTargetPlayerSelection(
+              action.behavior.outputs,
+            );
             if (targetInfo) {
               setPendingActionTargetPlayer({
                 cardId: action.cardId,
@@ -1338,7 +1505,10 @@ export default function GameInterface() {
               });
               setShowActionTargetPlayerSelection(true);
             } else {
-              void globalWebSocketManager.playCardAction(action.cardId, action.behaviorIndex);
+              void globalWebSocketManager.playCardAction(
+                action.cardId,
+                action.behaviorIndex,
+              );
             }
           }
         }
@@ -1422,7 +1592,10 @@ export default function GameInterface() {
   const handleTabTakeOver = () => {
     if (conflictingTabInfo) {
       const tabManager = getTabManager();
-      tabManager.forceTakeOver(conflictingTabInfo.gameId, conflictingTabInfo.playerName);
+      tabManager.forceTakeOver(
+        conflictingTabInfo.gameId,
+        conflictingTabInfo.playerName,
+      );
       setShowTabConflict(false);
       setConflictingTabInfo(null);
 
@@ -1470,7 +1643,10 @@ export default function GameInterface() {
       setLoadingPhase("connecting");
 
       const tabManager = getTabManager();
-      const canClaim = await tabManager.claimTab(gameForSelection.id, playerName);
+      const canClaim = await tabManager.claimTab(
+        gameForSelection.id,
+        playerName,
+      );
 
       if (!canClaim) {
         const activeTabInfo = tabManager.getActiveTabInfo();
@@ -1492,7 +1668,10 @@ export default function GameInterface() {
       setPlayerId(selectedPlayerId);
       globalWebSocketManager.setCurrentPlayerId(selectedPlayerId);
 
-      await globalWebSocketManager.playerTakeover(selectedPlayerId, gameForSelection.id);
+      await globalWebSocketManager.playerTakeover(
+        selectedPlayerId,
+        gameForSelection.id,
+      );
 
       setLoadingPhase("ready");
     },
@@ -1530,7 +1709,10 @@ export default function GameInterface() {
       try {
         fetchedGame = await apiService.getGame(gameId, savedSession?.playerId);
       } catch {
-        navigate("/", { replace: true, state: { error: "Could not find game" } });
+        navigate("/", {
+          replace: true,
+          state: { error: "Could not find game" },
+        });
         return;
       }
 
@@ -1538,7 +1720,10 @@ export default function GameInterface() {
 
       if (!fetchedGame) {
         clearGameSession();
-        navigate("/", { replace: true, state: { error: "Could not find game" } });
+        navigate("/", {
+          replace: true,
+          state: { error: "Could not find game" },
+        });
         return;
       }
 
@@ -1547,11 +1732,14 @@ export default function GameInterface() {
 
       if (cachedForThisGame && savedSession.playerId) {
         // Check if cached player exists in game
-        const allPlayers = [fetchedGame.currentPlayer, ...(fetchedGame.otherPlayers || [])].filter(
-          Boolean,
-        );
+        const allPlayers = [
+          fetchedGame.currentPlayer,
+          ...(fetchedGame.otherPlayers || []),
+        ].filter(Boolean);
 
-        const cachedPlayer = allPlayers.find((p) => p?.id === savedSession.playerId);
+        const cachedPlayer = allPlayers.find(
+          (p) => p?.id === savedSession.playerId,
+        );
 
         if (cachedPlayer) {
           // Player exists in game
@@ -1560,7 +1748,10 @@ export default function GameInterface() {
             setLoadingPhase("connecting");
 
             const tabManager = getTabManager();
-            const canClaim = await tabManager.claimTab(fetchedGame.id, savedSession.playerName);
+            const canClaim = await tabManager.claimTab(
+              fetchedGame.id,
+              savedSession.playerName,
+            );
             if (aborted) return;
 
             if (!canClaim) {
@@ -1576,7 +1767,10 @@ export default function GameInterface() {
             setPlayerId(savedSession.playerId);
             globalWebSocketManager.setCurrentPlayerId(savedSession.playerId);
 
-            await globalWebSocketManager.playerTakeover(savedSession.playerId, fetchedGame.id);
+            await globalWebSocketManager.playerTakeover(
+              savedSession.playerId,
+              fetchedGame.id,
+            );
             if (aborted) return;
 
             setLoadingPhase("ready");
@@ -1589,7 +1783,10 @@ export default function GameInterface() {
       // 4. If we have full route state with player info, use that directly
       if (routeState?.game && routeState?.playerId && routeState?.playerName) {
         const tabManager = getTabManager();
-        const canClaim = await tabManager.claimTab(routeState.game.id, routeState.playerName);
+        const canClaim = await tabManager.claimTab(
+          routeState.game.id,
+          routeState.playerName,
+        );
         if (aborted) return;
 
         if (!canClaim) {
@@ -1774,7 +1971,8 @@ export default function GameInterface() {
     if (loadingPhase === "connecting") return "Connecting...";
     if (isReconnecting && reconnectionStep) {
       if (reconnectionStep === "game") return "Reconnecting to game...";
-      if (reconnectionStep === "environment") return "Loading 3D environment...";
+      if (reconnectionStep === "environment")
+        return "Loading 3D environment...";
     }
     if (!isSkyboxReady) return "Loading 3D environment...";
     return "Connecting to game...";
@@ -1825,7 +2023,8 @@ export default function GameInterface() {
   // Pre-game phase covers both lobby AND starting card selection
   const isPreGamePhase =
     isLobbyPhase ||
-    (game?.status === GameStatusActive && game?.currentPhase === GamePhaseStartingCardSelection);
+    (game?.status === GameStatusActive &&
+      game?.currentPhase === GamePhaseStartingCardSelection);
 
   // Show waiting modal when player has finished card selection but others haven't
   const showWaitingForPlayers =
@@ -1888,7 +2087,11 @@ export default function GameInterface() {
       onConvertPlantsToGreenery: handleConvertPlantsToGreenery,
       onConvertHeatToTemperature: handleConvertHeatToTemperature,
     }),
-    [handleActionSelect, handleConvertPlantsToGreenery, handleConvertHeatToTemperature],
+    [
+      handleActionSelect,
+      handleConvertPlantsToGreenery,
+      handleConvertHeatToTemperature,
+    ],
   );
 
   // Check if we need the persistent backdrop (during overlay transitions)
@@ -1941,6 +2144,15 @@ export default function GameInterface() {
           vpIndicators={vpIndicators}
           triggeredEffects={triggeredEffects}
           bottomBarCallbacks={bottomBarCallbacks}
+          cards={!spectatePlayerId ? currentPlayer?.cards || [] : []}
+          hideCardFan={
+            showCardSelection ||
+            showPendingCardSelection ||
+            showCardDrawSelection ||
+            isPreGamePhase
+          }
+          onCardSelect={(_cardId) => {}}
+          onPlayCard={handlePlayCard}
           onStandardProjectSelect={handleStandardProjectSelect}
           onLeaveGame={handleLeaveGame}
           onSkyboxReady={handleSkyboxReady}
@@ -2006,8 +2218,9 @@ export default function GameInterface() {
           <TilePlacerWindow
             playerId={tilePlacerPlayerId}
             playerName={
-              [game.currentPlayer, ...game.otherPlayers].find((p) => p.id === tilePlacerPlayerId)
-                ?.name || tilePlacerPlayerId
+              [game.currentPlayer, ...game.otherPlayers].find(
+                (p) => p.id === tilePlacerPlayerId,
+              )?.name || tilePlacerPlayerId
             }
             onClose={() => setTilePlacerPlayerId(null)}
           />
@@ -2021,7 +2234,9 @@ export default function GameInterface() {
         loadingPhase === "joining") && (
         <div
           className={
-            transitionPhase === "fadeOutLobby" ? "animate-[fadeOut_1500ms_ease-out_forwards]" : ""
+            transitionPhase === "fadeOutLobby"
+              ? "animate-[fadeOut_1500ms_ease-out_forwards]"
+              : ""
           }
         >
           <SpaceBackground animationSpeed={0.5} overlayOpacity={0.3} />
@@ -2053,13 +2268,18 @@ export default function GameInterface() {
       {loadingPhase === "selecting" && gameForSelection && (
         <PlayerSelectionOverlay
           game={gameForSelection}
-          onSelectPlayer={(playerId, playerName) => void handlePlayerSelected(playerId, playerName)}
+          onSelectPlayer={(playerId, playerName) =>
+            void handlePlayerSelected(playerId, playerName)
+          }
           onCancel={handlePlayerSelectionCancel}
         />
       )}
 
       {loadingPhase === "joining" && gameForSelection && (
-        <JoinGameOverlay game={gameForSelection} onCancel={handlePlayerSelectionCancel} />
+        <JoinGameOverlay
+          game={gameForSelection}
+          onCancel={handlePlayerSelectionCancel}
+        />
       )}
 
       {/* Leave game confirmation dialog */}
@@ -2074,7 +2294,10 @@ export default function GameInterface() {
             You can reconnect to the game again without losing any progress.
           </p>
           <div className="flex gap-4 justify-center">
-            <GameMenuButton variant="secondary" onClick={() => setShowLeaveGameConfirm(false)}>
+            <GameMenuButton
+              variant="secondary"
+              onClick={() => setShowLeaveGameConfirm(false)}
+            >
               Cancel
             </GameMenuButton>
             <GameMenuButton variant="error" onClick={handleConfirmLeaveGame}>
@@ -2089,7 +2312,8 @@ export default function GameInterface() {
         isOpen={showCardSelection}
         cards={cardDetails}
         availableCorporations={
-          game?.currentPlayer?.selectStartingCardsPhase?.availableCorporations || []
+          game?.currentPlayer?.selectStartingCardsPhase
+            ?.availableCorporations || []
         }
         playerCredits={currentPlayer?.resources?.credits || 40}
         onSelectCards={handleCardSelection}
@@ -2137,7 +2361,9 @@ export default function GameInterface() {
                       allPlayers.push({
                         id: other.id,
                         name: other.name,
-                        isReady: !other.selectStartingCardsPhase && !!other.corporation,
+                        isReady:
+                          !other.selectStartingCardsPhase &&
+                          !!other.corporation,
                         isSelf: false,
                       });
                     });
@@ -2153,7 +2379,9 @@ export default function GameInterface() {
                         key={player.id}
                         className="flex justify-between items-center py-2 px-3 bg-black/40 rounded-lg border border-space-blue-600/50"
                       >
-                        <span className="text-white text-sm font-medium">{player.name}</span>
+                        <span className="text-white text-sm font-medium">
+                          {player.name}
+                        </span>
                         <div className="flex gap-1.5 items-center">
                           {player.isSelf && (
                             <span className="bg-space-blue-800 text-white py-0.5 px-1.5 rounded text-[10px] font-bold uppercase">
@@ -2211,33 +2439,6 @@ export default function GameInterface() {
           playerCredits={currentPlayer?.resources?.credits || 0}
           onConfirm={handleCardDrawConfirm}
         />
-      )}
-
-      {/* Card fan overlay for hand cards (hidden when spectating another player) */}
-      {game && currentPlayer && !spectatePlayerId && (
-        <div
-          className={
-            transitionPhase === "animateUI"
-              ? "animate-[uiFadeIn_1200ms_ease-out_both]"
-              : transitionPhase === "loading" || transitionPhase === "fadeOutLobby"
-                ? "opacity-0"
-                : ""
-          }
-        >
-          <CardFanOverlay
-            cards={currentPlayer.cards || []}
-            hideWhenModalOpen={
-              showCardSelection ||
-              showPendingCardSelection ||
-              showCardDrawSelection ||
-              isPreGamePhase
-            }
-            onCardSelect={(_cardId) => {
-              // TODO: Implement card selection logic (view details, etc.)
-            }}
-            onPlayCard={handlePlayCard}
-          />
-        </div>
       )}
 
       {/* End game overlay - shown when game is completed */}

--- a/frontend/src/components/layout/main/GameLayout.tsx
+++ b/frontend/src/components/layout/main/GameLayout.tsx
@@ -5,6 +5,7 @@ import RightSidebar from "../panels/RightSidebar.tsx";
 import MainContentDisplay from "../../ui/display/MainContentDisplay.tsx";
 import { TileHighlightMode } from "../../game/board/Tile.tsx";
 import { TileVPIndicator } from "../../ui/overlay/EndGameOverlay.tsx";
+import CardFanOverlay from "../../ui/overlay/CardFanOverlay.tsx";
 import BottomResourceBar, {
   BottomResourceBarCallbacks,
 } from "../../ui/overlay/BottomResourceBar.tsx";
@@ -15,6 +16,7 @@ import {
   PlayerDto,
   OtherPlayerDto,
   CardDto,
+  PlayerCardDto,
   TriggeredEffectDto,
 } from "../../../types/generated/api-types.ts";
 
@@ -39,6 +41,10 @@ interface GameLayoutProps {
   vpIndicators?: TileVPIndicator[];
   triggeredEffects?: TriggeredEffectDto[];
   bottomBarCallbacks?: BottomResourceBarCallbacks;
+  cards?: PlayerCardDto[];
+  hideCardFan?: boolean;
+  onCardSelect?: (cardId: string) => void;
+  onPlayCard?: (cardId: string) => Promise<void>;
   onStandardProjectSelect?: (project: StandardProject) => void;
   onLeaveGame?: () => void;
   onSkyboxReady?: () => void;
@@ -63,6 +69,10 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   vpIndicators = [],
   triggeredEffects = [],
   bottomBarCallbacks,
+  cards = [],
+  hideCardFan = false,
+  onCardSelect,
+  onPlayCard,
   onStandardProjectSelect,
   onLeaveGame,
   onSkyboxReady,
@@ -86,16 +96,23 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const allPlayers: (PlayerDto | OtherPlayerDto)[] =
     (gameState?.turnOrder
       ?.map((playerId) => playerMap.get(playerId))
-      .filter((player) => player !== undefined) as (PlayerDto | OtherPlayerDto)[]) || [];
+      .filter((player) => player !== undefined) as (
+      | PlayerDto
+      | OtherPlayerDto
+    )[]) || [];
 
   // Find the current turn player for the right sidebar
   const currentTurnPlayer =
     allPlayers.find((player) => player.id === gameState?.currentTurn) || null;
 
   const showUI =
-    transitionPhase === "animateUI" || transitionPhase === "complete" || transitionPhase === "idle";
+    transitionPhase === "animateUI" ||
+    transitionPhase === "complete" ||
+    transitionPhase === "idle";
   const isAnimatingIn = transitionPhase === "animateUI";
-  const uiAnimationClass = isAnimatingIn ? "animate-[uiFadeIn_1200ms_ease-out_both]" : "";
+  const uiAnimationClass = isAnimatingIn
+    ? "animate-[uiFadeIn_1200ms_ease-out_both]"
+    : "";
 
   return (
     <div className="relative w-screen h-screen bg-[#000000] text-white overflow-hidden">
@@ -156,6 +173,17 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           />
 
           <PlayerOverlay players={allPlayers} currentPlayer={currentPlayer} />
+        </div>
+      )}
+
+      {showUI && !showCardSelection && (
+        <div className={uiAnimationClass}>
+          <CardFanOverlay
+            cards={cards}
+            hideWhenModalOpen={hideCardFan}
+            onCardSelect={onCardSelect}
+            onPlayCard={onPlayCard}
+          />
         </div>
       )}
 

--- a/frontend/src/components/ui/overlay/BottomResourceBar.tsx
+++ b/frontend/src/components/ui/overlay/BottomResourceBar.tsx
@@ -42,7 +42,13 @@ const ANGLE_INDENT = 42;
 
 const BORDER_COLOR = "rgba(60,60,70,0.7)";
 
-const AngledPanel: React.FC<AngledPanelProps> = ({ side, corpColor, width, height, children }) => {
+const AngledPanel: React.FC<AngledPanelProps> = ({
+  side,
+  corpColor,
+  width,
+  height,
+  children,
+}) => {
   const fillPoints =
     side === "left"
       ? `0,0 ${width - ANGLE_INDENT},0 ${width},${height} 0,${height}`
@@ -83,8 +89,12 @@ const AngledPanel: React.FC<AngledPanelProps> = ({ side, corpColor, width, heigh
           )}
         </defs>
         <polygon points={fillPoints} fill="rgba(10,10,15,0.95)" />
-        {side === "left" && <polygon points={fillPoints} fill={`url(#${gradientId})`} />}
-        {side === "right" && <polygon points={fillPoints} fill={`url(#${whiteGlowId})`} />}
+        {side === "left" && (
+          <polygon points={fillPoints} fill={`url(#${gradientId})`} />
+        )}
+        {side === "right" && (
+          <polygon points={fillPoints} fill={`url(#${whiteGlowId})`} />
+        )}
         <line
           x1={topEdge.x1}
           y1={topEdge.y1}
@@ -151,11 +161,12 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
   onStopSpectating,
 }) => {
   const isSpectating = !!spectatingPlayer;
-  const displayPlayer: PlayerDto | OtherPlayerDto | null | undefined = isSpectating
-    ? spectatingPlayer
-    : currentPlayer;
+  const displayPlayer: PlayerDto | OtherPlayerDto | null | undefined =
+    isSpectating ? spectatingPlayer : currentPlayer;
   const displayCorporation = isSpectating ? spectatingCorporation : corporation;
-  const displayPlayedCards = isSpectating ? (spectatingPlayer?.playedCards ?? []) : playedCards;
+  const displayPlayedCards = isSpectating
+    ? (spectatingPlayer?.playedCards ?? [])
+    : playedCards;
 
   const {
     onOpenCardEffectsModal,
@@ -209,7 +220,10 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (corpContainerRef.current && !corpContainerRef.current.contains(event.target as Node)) {
+      if (
+        corpContainerRef.current &&
+        !corpContainerRef.current.contains(event.target as Node)
+      ) {
         handleCorpClose();
       }
     };
@@ -359,8 +373,14 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
     setShowTagsPopover(!showTagsPopover);
   };
 
-  const vpGranters = displayPlayer && "vpGranters" in displayPlayer ? displayPlayer.vpGranters : [];
-  const totalVP = (vpGranters || []).reduce((sum, g) => sum + g.computedValue, 0);
+  const vpGranters =
+    displayPlayer && "vpGranters" in displayPlayer
+      ? displayPlayer.vpGranters
+      : [];
+  const totalVP = (vpGranters || []).reduce(
+    (sum, g) => sum + g.computedValue,
+    0,
+  );
 
   const handleOpenVPPopover = () => {
     setShowVPPopover(!showVPPopover);
@@ -389,7 +409,7 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
   const contentScale = panelWidth / MAX_PANEL_WIDTH;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-[1000] flex justify-between pointer-events-none">
+    <div className="fixed bottom-0 left-0 right-0 flex justify-between pointer-events-none">
       {/* Spectating banner */}
       {isSpectating && (
         <div
@@ -408,12 +428,19 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
               </span>
             )}
           </span>
-          <span className="text-white/50 text-[10px] font-orbitron">ESC to close</span>
+          <span className="text-white/50 text-[10px] font-orbitron">
+            ESC to close
+          </span>
         </div>
       )}
 
       {/* LEFT PANEL: Corporation + Resources */}
-      <AngledPanel side="left" corpColor={corpColor} width={LEFT_PANEL_WIDTH} height={BAR_HEIGHT}>
+      <AngledPanel
+        side="left"
+        corpColor={corpColor}
+        width={LEFT_PANEL_WIDTH}
+        height={BAR_HEIGHT}
+      >
         <div
           className="flex items-center h-full origin-left"
           style={{
@@ -450,7 +477,9 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                 {showCorpExpanded && (
                   <div
                     className={`absolute bottom-[100%] left-4 mb-2 origin-bottom-left transition-all duration-200 ${
-                      isCorpExpanded ? "opacity-100 scale-100" : "opacity-0 scale-90"
+                      isCorpExpanded
+                        ? "opacity-100 scale-100"
+                        : "opacity-0 scale-90"
                     }`}
                   >
                     <button
@@ -467,8 +496,10 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                         id: displayCorporation.id,
                         name: displayCorporation.name,
                         description: displayCorporation.description,
-                        startingMegaCredits: displayCorporation.startingResources?.credits || 0,
-                        startingProduction: displayCorporation.startingProduction,
+                        startingMegaCredits:
+                          displayCorporation.startingResources?.credits || 0,
+                        startingProduction:
+                          displayCorporation.startingProduction,
                         startingResources: displayCorporation.startingResources,
                         behaviors: displayCorporation.behaviors,
                       }}
@@ -495,8 +526,12 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
           {/* Resources Section */}
           <div className="flex items-center justify-evenly flex-1">
             {playerResources.map((resource, index) => {
-              const resourceChanged = hasPathChanged(`currentPlayer.resources.${resource.id}`);
-              const productionChanged = hasPathChanged(`currentPlayer.production.${resource.id}`);
+              const resourceChanged = hasPathChanged(
+                `currentPlayer.resources.${resource.id}`,
+              );
+              const productionChanged = hasPathChanged(
+                `currentPlayer.production.${resource.id}`,
+              );
 
               const showConversionButton =
                 (resource.id === "plant" && canConvertPlants) ||
@@ -516,18 +551,23 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                         }`}
                       >
                         <button
-                          disabled={isConversionDisabled || !showConversionButton}
+                          disabled={
+                            isConversionDisabled || !showConversionButton
+                          }
                           className={`flex items-center justify-center gap-0.5 px-1.5 py-0.5 bg-black/80 border border-white/20 transition-all duration-200 ${
                             isConversionDisabled || !showConversionButton
                               ? "opacity-40 cursor-not-allowed"
                               : "cursor-pointer hover:bg-white/10 hover:border-white/40"
                           }`}
                           style={{
-                            borderColor: showConversionButton ? `${corpColor}60` : undefined,
+                            borderColor: showConversionButton
+                              ? `${corpColor}60`
+                              : undefined,
                           }}
                           onClick={(e) => {
                             e.stopPropagation();
-                            if (isConversionDisabled || !showConversionButton) return;
+                            if (isConversionDisabled || !showConversionButton)
+                              return;
                             hoverSound.onClick?.();
                             if (resource.id === "plant") {
                               void onConvertPlantsToGreenery?.();
@@ -541,7 +581,9 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                               : hoverSound.onMouseEnter
                           }
                         >
-                          <span className="text-[10px] font-bold text-white/90">+</span>
+                          <span className="text-[10px] font-bold text-white/90">
+                            +
+                          </span>
                           <GameIcon
                             iconType={
                               resource.id === "plant"
@@ -558,7 +600,9 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                     <div className="inline-flex items-center justify-center bg-[linear-gradient(135deg,rgba(160,110,60,0.5)_0%,rgba(139,89,42,0.45)_100%)] border border-[rgba(160,110,60,0.6)] px-3 py-0.5 w-[32px] mb-1">
                       <span
                         className={`text-[10px] font-bold font-orbitron text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.8)] leading-none tabular-nums ${
-                          productionChanged ? "[animation:valueUpdateShine_0.8s_ease-in-out]" : ""
+                          productionChanged
+                            ? "[animation:valueUpdateShine_0.8s_ease-in-out]"
+                            : ""
                         }`}
                       >
                         {resource.production}
@@ -576,10 +620,15 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
                       </div>
                     ) : (
                       <div className="flex items-center gap-1 w-[48px] justify-center scale-[0.85]">
-                        <GameIcon iconType={getResourceType(resource.id)} size="small" />
+                        <GameIcon
+                          iconType={getResourceType(resource.id)}
+                          size="small"
+                        />
                         <span
                           className={`text-sm font-bold font-orbitron text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.8)] tabular-nums w-[24px] text-left ${
-                            resourceChanged ? "[animation:valueUpdateShine_0.8s_ease-in-out]" : ""
+                            resourceChanged
+                              ? "[animation:valueUpdateShine_0.8s_ease-in-out]"
+                              : ""
                           }`}
                         >
                           {resource.current}
@@ -605,10 +654,18 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
       </AngledPanel>
 
       {/* RIGHT PANEL: Action Buttons */}
-      <AngledPanel side="right" corpColor={corpColor} width={RIGHT_PANEL_WIDTH} height={BAR_HEIGHT}>
+      <AngledPanel
+        side="right"
+        corpColor={corpColor}
+        width={RIGHT_PANEL_WIDTH}
+        height={BAR_HEIGHT}
+      >
         <div
           className="flex items-center h-full justify-evenly"
-          style={{ paddingLeft: ANGLE_INDENT + 16, paddingRight: ANGLE_INDENT + 16 }}
+          style={{
+            paddingLeft: ANGLE_INDENT + 16,
+            paddingRight: ANGLE_INDENT + 16,
+          }}
         >
           {/* Actions Button */}
           <button
@@ -621,8 +678,12 @@ const BottomResourceBar: React.FC<BottomResourceBarProps> = ({
             onMouseEnter={hoverSound.onMouseEnter}
           >
             <div className="font-bold flex items-center gap-[2px] h-[24px] w-[24px] justify-center text-[rgb(140,140,150)] group-hover:text-[rgb(100,160,220)] transition-colors duration-200">
-              <span className="text-[7px] leading-none translate-y-[1px]">●</span>
-              <span className="text-[7px] leading-none translate-y-[1px]">●</span>
+              <span className="text-[7px] leading-none translate-y-[1px]">
+                ●
+              </span>
+              <span className="text-[7px] leading-none translate-y-[1px]">
+                ●
+              </span>
               <span className="text-[18px] leading-none">→</span>
             </div>
             <div

--- a/frontend/src/components/ui/overlay/CardFanOverlay.tsx
+++ b/frontend/src/components/ui/overlay/CardFanOverlay.tsx
@@ -77,7 +77,9 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
   const [isInThrowZone, setIsInThrowZone] = useState(false);
   const [returningCard, setReturningCard] = useState<string | null>(null);
   const [throwError, setThrowError] = useState<string | null>(null);
-  const throwErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const throwErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const handRef = useRef<HTMLDivElement>(null);
   const cardsRef = useRef(cards);
@@ -166,7 +168,11 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
       }
       const delta = e.deltaY || e.deltaX;
       const maxScroll = Math.max(cardOrder.length - 1, 0);
-      scrollTargetRef.current = clamp(scrollTargetRef.current + delta * WHEEL_SCALE, 0, maxScroll);
+      scrollTargetRef.current = clamp(
+        scrollTargetRef.current + delta * WHEEL_SCALE,
+        0,
+        maxScroll,
+      );
       startScrollAnimation();
     },
     [draggedCard, highlightedCard, cardOrder.length, startScrollAnimation],
@@ -180,7 +186,10 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
   }, [handleWheel]);
 
   // --- Pointer events for drag ---
-  const handlePointerDown = (cardId: string, e: React.PointerEvent<HTMLDivElement>) => {
+  const handlePointerDown = (
+    cardId: string,
+    e: React.PointerEvent<HTMLDivElement>,
+  ) => {
     e.preventDefault();
     const cardEl = e.currentTarget;
     cardEl.setPointerCapture(e.pointerId);
@@ -193,7 +202,8 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
     const containerRect = handRef.current?.getBoundingClientRect();
 
     if (containerRect) {
-      const cardScreenX = containerRect.left + containerRect.width / 2 + transform.x;
+      const cardScreenX =
+        containerRect.left + containerRect.width / 2 + transform.x;
       // Include selected lift so the card doesn't snap down on grab
       const isSelected = highlightedCard === cardId;
       const liftY = isSelected ? SELECTED_LIFT : 0;
@@ -218,7 +228,8 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
       if (!containerRect) return;
       const cursorNearFan = pointerY >= containerRect.bottom - 80;
       if (!cursorNearFan) return;
-      const relativeX = pointerX - (containerRect.left + containerRect.width / 2);
+      const relativeX =
+        pointerX - (containerRect.left + containerRect.width / 2);
       const targetSlot = clamp(
         Math.round(relativeX / SPACING + scrollPos),
         0,
@@ -341,7 +352,14 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
         setReturningCard(null);
       }, 400);
     },
-    [draggedCard, dragStartPosition, highlightedCard, onPlayCard, onCardSelect, playCardHoverSound],
+    [
+      draggedCard,
+      dragStartPosition,
+      highlightedCard,
+      onPlayCard,
+      onCardSelect,
+      playCardHoverSound,
+    ],
   );
 
   // --- Click outside to deselect ---
@@ -397,14 +415,18 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
         if (isDraggedCard && !isReturning) {
           const containerRect = handRef.current?.getBoundingClientRect();
           if (containerRect) {
-            finalX = dragPosition.x + dragOffset.x - (containerRect.left + containerRect.width / 2);
+            finalX =
+              dragPosition.x +
+              dragOffset.x -
+              (containerRect.left + containerRect.width / 2);
             finalY = dragPosition.y + dragOffset.y - containerRect.bottom;
             finalRotation = 0;
             finalScale = 1;
             finalZ = 3000;
 
             const dragDeltaY = dragPosition.y - dragStartPosition.y;
-            isDragRaised = dragIntentRef.current && dragDeltaY < DRAG_RAISE_THRESHOLD;
+            isDragRaised =
+              dragIntentRef.current && dragDeltaY < DRAG_RAISE_THRESHOLD;
           }
         }
 
@@ -423,7 +445,9 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
           isDragging && !isReturning ? "is-dragging" : "",
           !isDraggedCard && draggedCard ? "is-reordering" : "",
           isReturning ? "is-returning" : "",
-          isDraggedCard && isInThrowZone && card.available ? "is-throw-zone" : "",
+          isDraggedCard && isInThrowZone && card.available
+            ? "is-throw-zone"
+            : "",
         ]
           .filter(Boolean)
           .join(" ");
@@ -446,13 +470,16 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
             <GameCard
               card={card}
               isSelected={
-                isHighlighted || (isDraggedCard && isInThrowZone && card.available === true)
+                isHighlighted ||
+                (isDraggedCard && isInThrowZone && card.available === true)
               }
               onSelect={() => {}}
               animationDelay={-1}
             />
             {!card.available && card.errors.length > 0 && (
-              <div className={`card-fan-error-panel ${showErrors ? "is-visible" : ""}`}>
+              <div
+                className={`card-fan-error-panel ${showErrors ? "is-visible" : ""}`}
+              >
                 {card.errors.map((err, i) => (
                   <div key={i} className="card-fan-error-item">
                     {err.message}
@@ -461,7 +488,9 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
               </div>
             )}
             {card.warnings && card.warnings.length > 0 && (
-              <div className={`card-fan-warning-panel ${showWarnings ? "is-visible" : ""}`}>
+              <div
+                className={`card-fan-warning-panel ${showWarnings ? "is-visible" : ""}`}
+              >
                 {card.warnings.map((warn, i) => (
                   <div key={i} className="card-fan-warning-item">
                     {warn.message}
@@ -481,7 +510,6 @@ const CardFanOverlay: React.FC<CardFanOverlayProps> = ({
           transform: translateX(-50%);
           width: 0;
           height: 300px;
-          z-index: 1100;
           pointer-events: none;
         }
 


### PR DESCRIPTION
## Summary
- Move CardFanOverlay from GameInterface into GameLayout, rendering it before BottomResourceBar so DOM painting order controls stacking naturally
- Remove explicit `z-index: 1100` from CardFanOverlay and `z-[1000]` from BottomResourceBar
- Cards in hand now render behind the bottom resource bar panels without z-index hacks

## Test plan
- [ ] Open a game — cards in hand render behind the bottom resource bar
- [ ] Scroll the card fan — cards scroll behind the bottom panel
- [ ] Click to select a card — the lifted card stays behind the bottom panel
- [ ] Drag/throw a card upward to play it — still works correctly
- [ ] Popovers from bottom bar (actions, effects, tags) still open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)