### PR TITLE
Only play asteroid sound on tile placement

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -387,13 +387,14 @@ export default function GameInterface() {
   const handleLogUpdate = useCallback(
     (logs: StateDiffDto[]) => {
       const ASTEROID_IMPACT_PATTERN = /asteroid|comet|impactor/i;
-      const hasAsteroidAction = logs.some(
+      const hasAsteroidPlacement = logs.some(
         (log) =>
           (log.sourceType === "card_play" ||
             log.sourceType === "standard_project") &&
-          ASTEROID_IMPACT_PATTERN.test(log.source),
+          ASTEROID_IMPACT_PATTERN.test(log.source) &&
+          (log.changes.boardChanges?.tilesPlaced?.length ?? 0) > 0,
       );
-      if (hasAsteroidAction) {
+      if (hasAsteroidPlacement) {
         void playAsteroidImpactSound();
       }
     },


### PR DESCRIPTION
## Summary
- Asteroid impact sound now only plays when the action actually places a tile on Mars
- Previously triggered for any asteroid/comet/impactor action, including temperature-only raises like Launch Asteroid

## Test plan
- [ ] Play a card that places an asteroid tile on Mars — sound should play
- [ ] Use Launch Asteroid standard project (temperature only) — sound should NOT play

🤖 Generated with [Claude Code](https://claude.com/claude-code)