### PR TITLE
Fix production 502: add nginx reverse proxy for API/WS

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,6 +23,28 @@ server {
         try_files $uri =404;
     }
 
+    # Proxy API requests to backend
+    location /api/ {
+        proxy_pass http://backend:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy WebSocket requests to backend
+    location /ws {
+        proxy_pass http://backend:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+
     # React Router - serve index.html for all other routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -17,6 +17,8 @@ services:
     image: ghcr.io/rackaracka123/terraforming-mars-frontend:latest
     container_name: tm-frontend
     restart: unless-stopped
+    environment:
+      - API_URL=/api/v1
     depends_on:
       - backend
     networks:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       dockerfile: Dockerfile
     container_name: tm-frontend
     restart: unless-stopped
+    environment:
+      - API_URL=/api/v1
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
## Summary
- Add `/api/` and `/ws` reverse proxy rules to nginx so requests reach the backend container
- Set `API_URL=/api/v1` in docker-compose so the frontend uses relative URLs instead of falling back to `http://localhost:3001`
- Fixes 502 Bad Gateway on production (Cloudflare tunnel → nginx → backend was broken because nginx had no proxy rules)

## Test plan
- [ ] Merge and wait for CI to build new frontend image
- [ ] Redeploy on mh-hemma (`docker compose pull && docker compose up -d`)
- [ ] Verify `https://terraforming-mars.rackaracka.net/` loads the app
- [ ] Verify `https://terraforming-mars.rackaracka.net/api/v1/cards` returns JSON
- [ ] Verify WebSocket connects for multiplayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)