### PR TITLE
Fix runtime-config.js being cached for 1 year

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -19,5 +19,9 @@ EOF
 echo "Runtime config generated at $CONFIG_FILE"
 echo "  API_URL: ${API_URL:-'(not set, will use default)'}"
 
+# Cache-bust the runtime-config.js reference in index.html
+CACHE_BUST=$(date +%s)
+sed -i "s|runtime-config.js|runtime-config.js?v=${CACHE_BUST}|g" /usr/share/nginx/html/index.html
+
 # Execute the CMD (nginx)
 exec "$@"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,6 +16,12 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Runtime config must not be cached (changes per deployment)
+    location = /runtime-config.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+
     # Serve static files with cache
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
## Summary
- Add explicit `no-cache` rule for `runtime-config.js` in nginx (it was matched by the `.js` catch-all with 1-year cache)
- Add cache-busting timestamp query param in `docker-entrypoint.sh` so stale CDN caches are bypassed on container restart

## Test plan
- [ ] Deploy and verify `runtime-config.js` has `Cache-Control: no-store, no-cache`
- [ ] Verify `/cards` page loads and shows cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)