### PR TITLE
fix: simplify nginx caching and support relative API URLs

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -19,9 +19,5 @@ EOF
 echo "Runtime config generated at $CONFIG_FILE"
 echo "  API_URL: ${API_URL:-'(not set, will use default)'}"
 
-# Cache-bust the runtime-config.js reference in index.html
-CACHE_BUST=$(date +%s)
-sed -i "s|runtime-config.js|runtime-config.js?v=${CACHE_BUST}|g" /usr/share/nginx/html/index.html
-
 # Execute the CMD (nginx)
 exec "$@"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,17 +16,10 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Runtime config must not be cached (changes per deployment)
-    location = /runtime-config.js {
-        add_header Cache-Control "no-store, no-cache, must-revalidate";
-        try_files $uri =404;
-    }
-
-    # Serve static files with cache
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    # Vite hashed assets - safe to cache forever
+    location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        try_files $uri =404;
     }
 
     # Proxy API requests to backend

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -72,7 +72,7 @@ export class ApiService {
 
   async getGame(gameId: string, playerId?: string): Promise<GameDto | null> {
     try {
-      const url = new URL(`${this.baseUrl}/games/${gameId}`);
+      const url = new URL(`${this.baseUrl}/games/${gameId}`, window.location.origin);
       if (playerId) {
         url.searchParams.set("playerId", playerId);
       }
@@ -98,7 +98,7 @@ export class ApiService {
 
   async listGames(status?: string): Promise<GameDto[]> {
     try {
-      const url = new URL(`${this.baseUrl}/games`);
+      const url = new URL(`${this.baseUrl}/games`, window.location.origin);
       if (status) {
         url.searchParams.set("status", status);
       }
@@ -120,7 +120,7 @@ export class ApiService {
 
   async listCards(offset: number = 0, limit: number = 50): Promise<ListCardsResponse> {
     try {
-      const url = new URL(`${this.baseUrl}/cards`);
+      const url = new URL(`${this.baseUrl}/cards`, window.location.origin);
       url.searchParams.set("offset", offset.toString());
       url.searchParams.set("limit", limit.toString());
 
@@ -141,7 +141,7 @@ export class ApiService {
 
   async getGameLogs(gameId: string, since?: number): Promise<StateDiffDto[]> {
     try {
-      const url = new URL(`${this.baseUrl}/games/${gameId}/logs`);
+      const url = new URL(`${this.baseUrl}/games/${gameId}/logs`, window.location.origin);
       if (since !== undefined) {
         url.searchParams.set("since", since.toString());
       }


### PR DESCRIPTION
## Summary
- Only cache Vite hashed assets under `/assets/` instead of all static files by extension — removes fragile per-file no-cache exceptions
- Remove cache-bust `sed` hack from `docker-entrypoint.sh` (no longer needed)
- Fix `new URL()` calls in `apiService.ts` to work with relative base URLs (`/api/v1`) in production

## Test plan
- [ ] `curl -sI .../runtime-config.js` should NOT have `max-age=31536000`
- [ ] `curl -sI .../assets/index-*.js` should have `max-age=31536000`
- [ ] `/cards` page loads cards in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)