### PR TITLE
fix: increase max players from 5 to 10

### DIFF
--- a/backend/internal/delivery/dto/http_dto.go
+++ b/backend/internal/delivery/dto/http_dto.go
@@ -2,7 +2,7 @@ package dto
 
 // CreateGameRequest represents the request body for creating a game
 type CreateGameRequest struct {
-	MaxPlayers      int      `json:"maxPlayers" binding:"required,min=1,max=5" ts:"number"`
+	MaxPlayers      int      `json:"maxPlayers" binding:"required,min=1,max=10" ts:"number"`
 	DevelopmentMode bool     `json:"developmentMode" ts:"boolean"`
 	CardPacks       []string `json:"cardPacks,omitempty" ts:"string[] | undefined"`
 }

--- a/backend/internal/game/game_settings.go
+++ b/backend/internal/game/game_settings.go
@@ -6,7 +6,7 @@ import (
 
 // GameSettings contains configurable game parameters (all optional)
 type GameSettings struct {
-	MaxPlayers      int      // Default: 5
+	MaxPlayers      int      // Default: 10
 	Temperature     *int     // Default: -30°C
 	Oxygen          *int     // Default: 0%
 	Oceans          *int     // Default: 0
@@ -24,7 +24,7 @@ const (
 
 // Default values for game settings
 const (
-	DefaultMaxPlayers  = 5
+	DefaultMaxPlayers  = 10
 	DefaultTemperature = global_parameters.MinTemperature // -30°C
 	DefaultOxygen      = global_parameters.MinOxygen      // 0%
 	DefaultOceans      = global_parameters.MinOceans      // 0


### PR DESCRIPTION
## Summary
- Increased `DefaultMaxPlayers` from 5 to 10 in game settings
- Updated HTTP DTO validation constraint from `max=5` to `max=10`

## Test plan
- [ ] Create a game and verify up to 10 players can join
- [ ] Verify creating a game with >10 players is rejected by validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)