### PR TITLE
feat: allow configuring max players in game creation lobby

### DIFF
--- a/frontend/src/components/pages/CreateGamePage.tsx
+++ b/frontend/src/components/pages/CreateGamePage.tsx
@@ -15,6 +15,7 @@ const CreateGamePage: React.FC = () => {
   const { showNotification } = useNotifications();
   const [playerName, setPlayerName] = useState("");
   const [developmentMode, setDevelopmentMode] = useState(true);
+  const [maxPlayers, setMaxPlayers] = useState(4);
   const [selectedPacks, setSelectedPacks] = useState<string[]>(["base-game"]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStep, setLoadingStep] = useState<"game" | "environment" | null>(null);
@@ -53,7 +54,7 @@ const CreateGamePage: React.FC = () => {
     try {
       // Step 1: Create game
       const gameSettings: GameSettingsDto = {
-        maxPlayers: 4, // Default max players
+        maxPlayers: maxPlayers,
         developmentMode: developmentMode,
         cardPacks: selectedPacks,
         demoGame: false,
@@ -257,6 +258,23 @@ const CreateGamePage: React.FC = () => {
               >
                 <div className="mb-4">
                   <h3 className="text-white text-sm font-semibold mb-3 text-center">Settings</h3>
+                  <label className="flex items-center gap-3 py-2 px-2 rounded hover:bg-white/5 transition-all duration-200">
+                    <span className="text-white text-sm font-medium leading-none m-0 flex items-center gap-2">
+                      Max Players
+                    </span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={10}
+                      value={maxPlayers}
+                      onChange={(e) => {
+                        const val = parseInt(e.target.value, 10);
+                        if (val >= 1 && val <= 10) setMaxPlayers(val);
+                      }}
+                      disabled={isLoading}
+                      className="w-16 bg-black/50 border border-white/20 rounded-lg py-1 px-2 text-white text-sm text-center outline-none focus:border-white/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                    />
+                  </label>
                   <label className="flex items-center gap-3 cursor-pointer py-2 px-2 rounded hover:bg-white/5 transition-all duration-200">
                     <input
                       type="checkbox"

--- a/frontend/src/components/pages/JoinGamePage.tsx
+++ b/frontend/src/components/pages/JoinGamePage.tsx
@@ -99,7 +99,7 @@ const JoinGamePage: React.FC = () => {
   const selectedPlayerCount = selectedGame
     ? (selectedGame.currentPlayer ? 1 : 0) + (selectedGame.otherPlayers?.length || 0)
     : 0;
-  const selectedMaxPlayers = selectedGame?.settings?.maxPlayers || 4;
+  const selectedMaxPlayers = selectedGame?.settings?.maxPlayers || 10;
 
   return (
     <div
@@ -208,7 +208,7 @@ const JoinGamePage: React.FC = () => {
                       .map((game, index) => {
                         const playerCount =
                           (game.currentPlayer ? 1 : 0) + (game.otherPlayers?.length || 0);
-                        const maxPlayers = game.settings?.maxPlayers || 4;
+                        const maxPlayers = game.settings?.maxPlayers || 10;
                         const hostName =
                           game.currentPlayer?.name || game.otherPlayers?.[0]?.name || "Unknown";
                         const isActive = game.status === "active";

--- a/frontend/src/components/ui/popover/EnterCodePopover.tsx
+++ b/frontend/src/components/ui/popover/EnterCodePopover.tsx
@@ -68,7 +68,7 @@ const EnterCodePopover: React.FC<EnterCodePopoverProps> = ({
 
       if (
         (game.currentPlayer ? 1 : 0) + (game.otherPlayers?.length || 0) >=
-        (game.settings?.maxPlayers || 4)
+        (game.settings?.maxPlayers || 10)
       ) {
         throw new Error("Game is full");
       }


### PR DESCRIPTION
## Summary
- Add a max players number input (1-10) to the Settings panel on the create game page, defaulting to 4
- Wire the configurable value into the `gameSettings` sent to the backend
- Fix fallback values in JoinGamePage and EnterCodePopover from `|| 4` to `|| 10` to match backend `DefaultMaxPlayers`

Closes #269

## Test plan
- [ ] Create a game — Settings panel shows max players input defaulting to 4
- [ ] Change max players to 6, create game — lobby shows `1/6 Players`
- [ ] Join page game list shows correct `X/Y Players` counts
- [ ] Enter code popover correctly rejects joining a full game based on configured max
- [ ] `make lint` and `make format` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)