### PR TITLE
fix: auto-scroll game log to bottom on open

### DIFF
--- a/frontend/src/components/ui/GamePopover/GamePopover.tsx
+++ b/frontend/src/components/ui/GamePopover/GamePopover.tsx
@@ -19,6 +19,7 @@ const GamePopover: React.FC<GamePopoverProps> = ({
   children,
   className = "",
   excludeRef,
+  contentRef,
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [computedPosition, setComputedPosition] = useState<{
@@ -141,7 +142,10 @@ const GamePopover: React.FC<GamePopoverProps> = ({
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto [scrollbar-width:thin] [scrollbar-color:var(--popover-accent)_rgba(30,60,150,0.3)] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-[rgba(30,60,150,0.3)] [&::-webkit-scrollbar-track]:rounded [&::-webkit-scrollbar-thumb]:bg-[var(--popover-accent)]/70 [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb:hover]:bg-[var(--popover-accent)]">
+      <div
+        ref={contentRef}
+        className="flex-1 overflow-y-auto [scrollbar-width:thin] [scrollbar-color:var(--popover-accent)_rgba(30,60,150,0.3)] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-[rgba(30,60,150,0.3)] [&::-webkit-scrollbar-track]:rounded [&::-webkit-scrollbar-thumb]:bg-[var(--popover-accent)]/70 [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb:hover]:bg-[var(--popover-accent)]"
+      >
         {children}
       </div>
     </div>,

--- a/frontend/src/components/ui/GamePopover/types.ts
+++ b/frontend/src/components/ui/GamePopover/types.ts
@@ -44,6 +44,7 @@ export interface GamePopoverProps {
   children: React.ReactNode;
   className?: string;
   excludeRef?: React.RefObject<HTMLElement | null>;
+  contentRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 export type PopoverItemState = "available" | "disabled" | "claimed";

--- a/frontend/src/components/ui/popover/LogPopover.tsx
+++ b/frontend/src/components/ui/popover/LogPopover.tsx
@@ -329,6 +329,7 @@ const LogPopover: React.FC<LogPopoverProps> = ({
 }) => {
   const [logs, setLogs] = useState<StateDiffDto[]>([]);
   const lastSequenceRef = useRef<number>(0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const playerNames = useMemo(() => {
     const names = new Map<string, string>();
@@ -374,6 +375,16 @@ const LogPopover: React.FC<LogPopoverProps> = ({
     lastSequenceRef.current = 0;
   }, [gameId]);
 
+  useEffect(() => {
+    if (!isVisible || logs.length === 0) return;
+    requestAnimationFrame(() => {
+      const el = scrollContainerRef.current;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    });
+  }, [isVisible, logs]);
+
   const groupedLogs = useMemo(() => groupLogsByGeneration(logs), [logs]);
 
   const playerColorMap = useMemo(() => {
@@ -402,6 +413,7 @@ const LogPopover: React.FC<LogPopoverProps> = ({
       arrow={{ enabled: true, position: "right", offset: 30 }}
       width={350}
       maxHeight={400}
+      contentRef={scrollContainerRef}
     >
       {logs.length === 0 ? (
         <div className="flex items-center justify-center py-10 px-5">


### PR DESCRIPTION
## Summary
- Adds `contentRef` prop to `GamePopover` so consumers can access the scrollable content div
- `LogPopover` uses this ref to auto-scroll to the bottom when the popover opens and when new log entries arrive
- Uses `requestAnimationFrame` to ensure the DOM has rendered before scrolling

Closes #259

## Test plan
- [ ] Open log popover mid-game — should show newest entries at the bottom
- [ ] Leave popover open while actions happen — should auto-scroll to new entries
- [ ] Verify other popovers (actions, effects, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)