### PR TITLE
fix: settings gear button not clickable in lobby/waiting phases

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -2516,9 +2516,7 @@ export default function GameInterface() {
       {/* Waiting for other players to finish card selection */}
       {showWaitingForPlayers && game && (
         <>
-          <div className="z-[10000]">
-            <MainMenuSettingsButton />
-          </div>
+          <MainMenuSettingsButton />
           <div className="fixed inset-0 z-[1000] flex items-center justify-center">
             <div className="w-[450px] max-w-[90vw] bg-space-black-darker/95 border-2 border-space-blue-400 rounded-[20px] p-8 backdrop-blur-space shadow-[0_20px_60px_rgba(0,0,0,0.6),0_0_40px_rgba(30,60,150,0.3)] animate-[modalFadeIn_0.3s_ease-out]">
               <div className="text-center mb-6">

--- a/frontend/src/components/ui/buttons/MainMenuSettingsButton.tsx
+++ b/frontend/src/components/ui/buttons/MainMenuSettingsButton.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import SoundToggleButton from "./SoundToggleButton.tsx";
 import GameMenuButton from "./GameMenuButton.tsx";
 import { GamePopover } from "../GamePopover";
+import { Z_INDEX } from "@/constants/zIndex.ts";
 
 const MainMenuSettingsButton: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -23,7 +24,10 @@ const MainMenuSettingsButton: React.FC = () => {
   return (
     <>
       {!isFullscreen && (
-        <div className="fixed top-[30px] left-1/2 -translate-x-1/2 z-50">
+        <div
+          className="fixed top-[30px] left-1/2 -translate-x-1/2"
+          style={{ zIndex: Z_INDEX.POPOVER }}
+        >
           <GameMenuButton
             variant="secondary"
             size="sm"
@@ -49,7 +53,7 @@ const MainMenuSettingsButton: React.FC = () => {
           </GameMenuButton>
         </div>
       )}
-      <div className="fixed top-[30px] right-[30px] z-50">
+      <div className="fixed top-[30px] right-[30px]" style={{ zIndex: Z_INDEX.POPOVER }}>
         <GameMenuButton
           ref={gearButtonRef}
           variant="secondary"

--- a/frontend/src/components/ui/overlay/GameMenuModal.tsx
+++ b/frontend/src/components/ui/overlay/GameMenuModal.tsx
@@ -101,11 +101,7 @@ const GameMenuModal: React.FC<GameMenuModalProps> = ({
           &larr; Back
         </GameMenuButton>
       )}
-      {showSettings && (
-        <div className="z-[10000]">
-          <MainMenuSettingsButton />
-        </div>
-      )}
+      {showSettings && <MainMenuSettingsButton />}
       <div
         className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[450px] max-w-[90vw] ${animationClass}`}
         style={{ zIndex }}

--- a/frontend/src/components/ui/overlay/StartingCardSelectionOverlay.tsx
+++ b/frontend/src/components/ui/overlay/StartingCardSelectionOverlay.tsx
@@ -15,6 +15,7 @@ import {
   RESOURCE_DISPLAY_CLASS,
 } from "./overlayStyles.ts";
 import GameMenuButton from "../buttons/GameMenuButton.tsx";
+import MainMenuSettingsButton from "../buttons/MainMenuSettingsButton.tsx";
 
 interface StartingCardSelectionOverlayProps {
   isOpen: boolean;
@@ -87,6 +88,7 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
 
   return (
     <div className="fixed inset-0 z-[1000] flex items-center justify-center animate-[fadeIn_0.3s_ease]">
+      <MainMenuSettingsButton />
       {/* Content container */}
       <div className={OVERLAY_CONTAINER_CLASS}>
         {/* Header */}


### PR DESCRIPTION
## Summary
- Fixed z-index stacking issue where `MainMenuSettingsButton` used `z-50` (below modal overlays at `z-1000`+), making it unclickable during lobby, waiting-for-players, and card-selection phases
- Bumped both fixed containers in `MainMenuSettingsButton` to use `Z_INDEX.POPOVER` (10001) from the centralized constant
- Removed ineffective wrapper `<div className="z-[10000]">` elements in `GameMenuModal` and `GameInterface` (they had no effect without positioning context)
- Added `MainMenuSettingsButton` to `StartingCardSelectionOverlay` which previously didn't render it at all

## Test plan
- [ ] Settings gear is clickable in the lobby/waiting room
- [ ] Settings gear is clickable during card selection phase
- [ ] Settings gear is clickable when waiting for other players
- [ ] Settings gear popover opens and closes correctly in all phases
- [ ] Settings gear is clickable during normal gameplay (no regression)

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)