### PR TITLE
fix: triggered effect notifications not showing for all players (#264)

### DIFF
--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -109,7 +109,6 @@ func ToGameDto(g *game.Game, cardRegistry cards.CardRegistry, playerID string) G
 		for i, effect := range triggeredEffects {
 			triggeredEffectDtos[i] = ToTriggeredEffectDto(effect)
 		}
-		g.ClearTriggeredEffects()
 	}
 
 	return GameDto{

--- a/backend/internal/delivery/websocket/broadcaster.go
+++ b/backend/internal/delivery/websocket/broadcaster.go
@@ -81,6 +81,9 @@ func (b *Broadcaster) BroadcastGameState(gameID string, playerIDs []string) {
 		}
 	}
 
+	// Clear triggered effects after all players have received them
+	g.ClearTriggeredEffects()
+
 	// Broadcast any new log entries since the last broadcast
 	b.broadcastNewLogs(gameID, playerIDs)
 

--- a/backend/test/delivery/dto/mapper_game_triggered_effects_test.go
+++ b/backend/test/delivery/dto/mapper_game_triggered_effects_test.go
@@ -1,0 +1,44 @@
+package dto_test
+
+import (
+	"testing"
+
+	"terraforming-mars-backend/internal/delivery/dto"
+	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/test/testutil"
+)
+
+// TestToGameDto_TriggeredEffectsNotCleared verifies that calling ToGameDto
+// multiple times for different players returns the same triggered effects.
+// This is critical for multiplayer: the mapper must not mutate game state.
+func TestToGameDto_TriggeredEffectsNotCleared(t *testing.T) {
+	mockBroadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 3, mockBroadcaster)
+	cardRegistry := testutil.CreateTestCardRegistry()
+
+	players := testGame.GetAllPlayers()
+
+	testGame.AddTriggeredEffect(game.TriggeredEffect{
+		CardName:   "Test Card",
+		PlayerID:   players[0].ID(),
+		SourceType: game.SourceTypePassiveEffect,
+	})
+
+	// Build DTOs for each player sequentially (same order as broadcaster loop)
+	for _, p := range players {
+		gameDto := dto.ToGameDto(testGame, cardRegistry, p.ID())
+
+		if len(gameDto.TriggeredEffects) != 1 {
+			t.Fatalf("player %s: expected 1 triggered effect, got %d", p.ID(), len(gameDto.TriggeredEffects))
+		}
+		if gameDto.TriggeredEffects[0].CardName != "Test Card" {
+			t.Fatalf("player %s: expected card name 'Test Card', got '%s'", p.ID(), gameDto.TriggeredEffects[0].CardName)
+		}
+	}
+
+	// Effects should still be present on the game until explicitly cleared
+	effects := testGame.GetTriggeredEffects()
+	if len(effects) != 1 {
+		t.Fatalf("expected triggered effects to still be present on game, got %d", len(effects))
+	}
+}


### PR DESCRIPTION
## Summary
- Moved `ClearTriggeredEffects()` from the DTO mapper (`ToGameDto`) to the broadcaster, after the player broadcast loop completes
- The mapper was clearing effects after building the first player's DTO, so all subsequent players in the loop saw no triggered effects
- Added test verifying `ToGameDto` can be called multiple times without losing triggered effects

## Test plan
- [x] New unit test: `TestToGameDto_TriggeredEffectsNotCleared` — calls `ToGameDto` for 3 players sequentially and asserts all see the same triggered effect
- [x] All existing backend tests pass (`make test`)
- [ ] Manual test: start a 3+ player game, play a card with triggered effects, verify all players see the notification

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)