### PR TITLE
feat: make demo tile picker dynamic

### DIFF
--- a/backend/internal/action/admin/start_tile_selection.go
+++ b/backend/internal/action/admin/start_tile_selection.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/player"
 )
 
@@ -36,22 +37,7 @@ func (a *StartTileSelectionAction) Execute(ctx context.Context, gameID string, p
 	)
 	log.Info("🗺️ Admin: Starting tile selection")
 
-	validTileTypes := map[string]bool{
-		"city":             true,
-		"greenery":         true,
-		"ocean":            true,
-		"volcano":          true,
-		"colony":           true,
-		"natural-preserve": true,
-		"mining":           true,
-		"nuclear-zone":     true,
-		"ecological-zone":  true,
-		"mohole":           true,
-		"restricted":       true,
-		"land-claim":       true,
-		"clear":            true,
-	}
-	if !validTileTypes[tileType] {
+	if !board.ValidPlaceableTileType(tileType) {
 		log.Error("Invalid tile type", zap.String("tile_type", tileType))
 		return fmt.Errorf("invalid tile type: %s", tileType)
 	}

--- a/backend/internal/delivery/dto/game_dto.go
+++ b/backend/internal/delivery/dto/game_dto.go
@@ -671,25 +671,33 @@ type OtherPlayerDto struct {
 
 // GameDto represents a game for client consumption (clean architecture)
 type GameDto struct {
-	ID               string               `json:"id" ts:"string"`
-	Status           GameStatus           `json:"status" ts:"GameStatus"`
-	Settings         GameSettingsDto      `json:"settings" ts:"GameSettingsDto"`
-	HostPlayerID     string               `json:"hostPlayerId" ts:"string"`
-	CurrentPhase     GamePhase            `json:"currentPhase" ts:"GamePhase"`
-	GlobalParameters GlobalParametersDto  `json:"globalParameters" ts:"GlobalParametersDto"`
-	CurrentPlayer    PlayerDto            `json:"currentPlayer" ts:"PlayerDto"`       // Viewing player's full data
-	OtherPlayers     []OtherPlayerDto     `json:"otherPlayers" ts:"OtherPlayerDto[]"` // Other players' limited data
-	ViewingPlayerID  string               `json:"viewingPlayerId" ts:"string"`        // The player viewing this game state
-	CurrentTurn      *string              `json:"currentTurn" ts:"string|null"`       // Whose turn it is (nullable)
-	Generation       int                  `json:"generation" ts:"number"`
-	TurnOrder        []string             `json:"turnOrder" ts:"string[]"`                                          // Turn order of all players in game
-	Board            BoardDto             `json:"board" ts:"BoardDto"`                                              // Game board with tiles and occupancy state
-	PaymentConstants PaymentConstantsDto  `json:"paymentConstants" ts:"PaymentConstantsDto"`                        // Conversion rates for alternative payments
-	Milestones       []MilestoneDto       `json:"milestones" ts:"MilestoneDto[]"`                                   // All milestones with claim status
-	Awards           []AwardDto           `json:"awards" ts:"AwardDto[]"`                                           // All awards with funding status
-	AwardResults     []AwardResultDto     `json:"awardResults" ts:"AwardResultDto[]"`                               // Current award placements (1st/2nd place per award)
-	FinalScores      []FinalScoreDto      `json:"finalScores,omitempty" ts:"FinalScoreDto[] | undefined"`           // Final scores (only when game completed)
-	TriggeredEffects []TriggeredEffectDto `json:"triggeredEffects,omitempty" ts:"TriggeredEffectDto[] | undefined"` // Recently triggered passive effects
+	ID                 string                 `json:"id" ts:"string"`
+	Status             GameStatus             `json:"status" ts:"GameStatus"`
+	Settings           GameSettingsDto        `json:"settings" ts:"GameSettingsDto"`
+	HostPlayerID       string                 `json:"hostPlayerId" ts:"string"`
+	CurrentPhase       GamePhase              `json:"currentPhase" ts:"GamePhase"`
+	GlobalParameters   GlobalParametersDto    `json:"globalParameters" ts:"GlobalParametersDto"`
+	CurrentPlayer      PlayerDto              `json:"currentPlayer" ts:"PlayerDto"`       // Viewing player's full data
+	OtherPlayers       []OtherPlayerDto       `json:"otherPlayers" ts:"OtherPlayerDto[]"` // Other players' limited data
+	ViewingPlayerID    string                 `json:"viewingPlayerId" ts:"string"`        // The player viewing this game state
+	CurrentTurn        *string                `json:"currentTurn" ts:"string|null"`       // Whose turn it is (nullable)
+	Generation         int                    `json:"generation" ts:"number"`
+	TurnOrder          []string               `json:"turnOrder" ts:"string[]"`                                          // Turn order of all players in game
+	Board              BoardDto               `json:"board" ts:"BoardDto"`                                              // Game board with tiles and occupancy state
+	PaymentConstants   PaymentConstantsDto    `json:"paymentConstants" ts:"PaymentConstantsDto"`                        // Conversion rates for alternative payments
+	Milestones         []MilestoneDto         `json:"milestones" ts:"MilestoneDto[]"`                                   // All milestones with claim status
+	Awards             []AwardDto             `json:"awards" ts:"AwardDto[]"`                                           // All awards with funding status
+	AwardResults       []AwardResultDto       `json:"awardResults" ts:"AwardResultDto[]"`                               // Current award placements (1st/2nd place per award)
+	FinalScores        []FinalScoreDto        `json:"finalScores,omitempty" ts:"FinalScoreDto[] | undefined"`           // Final scores (only when game completed)
+	TriggeredEffects   []TriggeredEffectDto   `json:"triggeredEffects,omitempty" ts:"TriggeredEffectDto[] | undefined"` // Recently triggered passive effects
+	PlaceableTileTypes []PlaceableTileTypeDto `json:"placeableTileTypes" ts:"PlaceableTileTypeDto[]"`                   // Available tile types for the demo tile picker
+}
+
+// PlaceableTileTypeDto represents a tile type available for placement in the demo tile picker
+type PlaceableTileTypeDto struct {
+	Type  string `json:"type" ts:"string"`
+	Label string `json:"label" ts:"string"`
+	Group string `json:"group" ts:"string"`
 }
 
 // Board-related DTOs for tygo generation

--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -120,20 +120,34 @@ func ToGameDto(g *game.Game, cardRegistry cards.CardRegistry, playerID string) G
 		GlobalParameters: globalParamsDto,
 		CurrentPlayer:    currentPlayer,
 		OtherPlayers:     otherPlayers,
-		ViewingPlayerID:  playerID, // The player viewing this game state
+		ViewingPlayerID:  playerID,
 		CurrentTurn:      getCurrentTurnPlayerID(g),
 		Generation:       g.Generation(),
 		TurnOrder:        g.TurnOrder(),
 		Board: BoardDto{
 			Tiles: tileDtos,
 		},
-		PaymentConstants: paymentConstants,
-		Milestones:       ToMilestonesDto(g.Milestones()),
-		Awards:           ToAwardsDto(g.Awards()),
-		AwardResults:     ToAwardResultsDto(g, cardRegistry),
-		FinalScores:      finalScoreDtos,
-		TriggeredEffects: triggeredEffectDtos,
+		PaymentConstants:   paymentConstants,
+		Milestones:         ToMilestonesDto(g.Milestones()),
+		Awards:             ToAwardsDto(g.Awards()),
+		AwardResults:       ToAwardResultsDto(g, cardRegistry),
+		FinalScores:        finalScoreDtos,
+		TriggeredEffects:   triggeredEffectDtos,
+		PlaceableTileTypes: ToPlaceableTileTypeDtos(),
 	}
+}
+
+// ToPlaceableTileTypeDtos converts the board PlaceableTileTypes registry to DTOs
+func ToPlaceableTileTypeDtos() []PlaceableTileTypeDto {
+	dtos := make([]PlaceableTileTypeDto, len(board.PlaceableTileTypes))
+	for i, pt := range board.PlaceableTileTypes {
+		dtos[i] = PlaceableTileTypeDto{
+			Type:  pt.Type,
+			Label: pt.Label,
+			Group: pt.Group,
+		}
+	}
+	return dtos
 }
 
 // getCurrentTurnPlayerID extracts the player ID from the current turn

--- a/backend/internal/game/board/board.go
+++ b/backend/internal/game/board/board.go
@@ -21,7 +21,46 @@ const (
 	TileTypeEcologicalZone  = "ecological-zone"
 	TileTypeMohole          = "mohole"
 	TileTypeRestricted      = "restricted"
+	TileTypeVolcano         = "volcano"
+	TileTypeColony          = "colony"
+	TileTypeLandClaim       = "land-claim"
+	TileTypeClear           = "clear"
 )
+
+// PlaceableTileType describes a tile type available in the demo tile picker
+type PlaceableTileType struct {
+	Type  string
+	Label string
+	Group string
+}
+
+// PlaceableTileTypes is the single registry of all tile types available for placement.
+// Adding a new entry here automatically updates backend validation and frontend UI.
+var PlaceableTileTypes = []PlaceableTileType{
+	{Type: TileTypeCity, Label: "City", Group: "Base"},
+	{Type: TileTypeGreenery, Label: "Greenery", Group: "Base"},
+	{Type: TileTypeOcean, Label: "Ocean", Group: "Base"},
+	{Type: TileTypeNaturalPreserve, Label: "Natural Preserve", Group: "Special"},
+	{Type: TileTypeEcologicalZone, Label: "Ecological Zone", Group: "Special"},
+	{Type: TileTypeMining, Label: "Mining", Group: "Special"},
+	{Type: TileTypeColony, Label: "Colony", Group: "Special"},
+	{Type: TileTypeVolcano, Label: "Volcano", Group: "Industrial"},
+	{Type: TileTypeNuclearZone, Label: "Nuclear Zone", Group: "Industrial"},
+	{Type: TileTypeMohole, Label: "Mohole", Group: "Industrial"},
+	{Type: TileTypeRestricted, Label: "Restricted", Group: "Industrial"},
+	{Type: TileTypeLandClaim, Label: "Land Claim", Group: "Tools"},
+	{Type: TileTypeClear, Label: "Clear", Group: "Tools"},
+}
+
+// ValidPlaceableTileType returns true if the given tile type is in the PlaceableTileTypes registry
+func ValidPlaceableTileType(tileType string) bool {
+	for _, pt := range PlaceableTileTypes {
+		if pt.Type == tileType {
+			return true
+		}
+	}
+	return false
+}
 
 // BoardTag represents a tag on a board tile for reserved areas
 type BoardTag = string

--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -2427,6 +2427,7 @@ export default function GameInterface() {
               [game.currentPlayer, ...game.otherPlayers].find((p) => p.id === tilePlacerPlayerId)
                 ?.name || tilePlacerPlayerId
             }
+            placeableTileTypes={game.placeableTileTypes}
             onClose={() => setTilePlacerPlayerId(null)}
           />
         )}

--- a/frontend/src/components/ui/debug/TilePlacerWindow.tsx
+++ b/frontend/src/components/ui/debug/TilePlacerWindow.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { globalWebSocketManager } from "../../../services/globalWebSocketManager.ts";
 import {
   AdminCommandRequest,
   AdminCommandTypeStartTileSelection,
+  PlaceableTileTypeDto,
   StartTileSelectionAdminCommand,
 } from "../../../types/generated/api-types.ts";
 import { useWindowDrag, useWindowManager } from "./WindowManager.tsx";
@@ -10,6 +11,7 @@ import { useWindowDrag, useWindowManager } from "./WindowManager.tsx";
 interface TilePlacerWindowProps {
   playerId: string;
   playerName: string;
+  placeableTileTypes: PlaceableTileTypeDto[];
   onClose: () => void;
 }
 
@@ -21,43 +23,24 @@ interface TileGroup {
   tiles: { type: string; label: string }[];
 }
 
-const TILE_GROUPS: TileGroup[] = [
-  {
-    label: "Base",
-    tiles: [
-      { type: "city", label: "City" },
-      { type: "greenery", label: "Greenery" },
-      { type: "ocean", label: "Ocean" },
-    ],
-  },
-  {
-    label: "Special",
-    tiles: [
-      { type: "natural-preserve", label: "Natural Preserve" },
-      { type: "ecological-zone", label: "Ecological Zone" },
-      { type: "mining", label: "Mining" },
-      { type: "colony", label: "Colony" },
-    ],
-  },
-  {
-    label: "Industrial",
-    tiles: [
-      { type: "volcano", label: "Volcano" },
-      { type: "nuclear-zone", label: "Nuclear Zone" },
-      { type: "mohole", label: "Mohole" },
-      { type: "restricted", label: "Restricted" },
-    ],
-  },
-  {
-    label: "Tools",
-    tiles: [
-      { type: "land-claim", label: "Land Claim" },
-      { type: "clear", label: "Clear" },
-    ],
-  },
-];
-
-const TilePlacerWindow: React.FC<TilePlacerWindowProps> = ({ playerId, playerName, onClose }) => {
+const TilePlacerWindow: React.FC<TilePlacerWindowProps> = ({
+  playerId,
+  playerName,
+  placeableTileTypes,
+  onClose,
+}) => {
+  const tileGroups = useMemo((): TileGroup[] => {
+    const groupMap = new Map<string, { type: string; label: string }[]>();
+    const groupOrder: string[] = [];
+    for (const tile of placeableTileTypes) {
+      if (!groupMap.has(tile.group)) {
+        groupMap.set(tile.group, []);
+        groupOrder.push(tile.group);
+      }
+      groupMap.get(tile.group)!.push({ type: tile.type, label: tile.label });
+    }
+    return groupOrder.map((group) => ({ label: group, tiles: groupMap.get(group)! }));
+  }, [placeableTileTypes]);
   const { position, isDragging, handleMouseDown } = useWindowDrag({
     windowId: WINDOW_ID,
     width: WINDOW_WIDTH,
@@ -161,7 +144,7 @@ const TilePlacerWindow: React.FC<TilePlacerWindowProps> = ({ playerId, playerNam
           overflowY: "auto",
         }}
       >
-        {TILE_GROUPS.map((group) => (
+        {tileGroups.map((group) => (
           <div key={group.label}>
             <div
               style={{

--- a/frontend/src/types/generated/api-types.ts
+++ b/frontend/src/types/generated/api-types.ts
@@ -990,6 +990,15 @@ export interface GameDto {
   awardResults: AwardResultDto[]; // Current award placements (1st/2nd place per award)
   finalScores?: FinalScoreDto[]; // Final scores (only when game completed)
   triggeredEffects?: TriggeredEffectDto[]; // Recently triggered passive effects
+  placeableTileTypes: PlaceableTileTypeDto[]; // Available tile types for the demo tile picker
+}
+/**
+ * PlaceableTileTypeDto represents a tile type available for placement in the demo tile picker
+ */
+export interface PlaceableTileTypeDto {
+  type: string;
+  label: string;
+  group: string;
 }
 /**
  * TileBonusDto represents a resource bonus provided by a tile when occupied


### PR DESCRIPTION
## Summary
- Add `PlaceableTileTypes` registry in `board.go` as single source of truth for all placeable tile types
- Replace hardcoded `validTileTypes` map in `start_tile_selection.go` with `board.ValidPlaceableTileType()`
- Add `PlaceableTileTypeDto` to `GameDto` so frontend receives tile types dynamically
- Remove hardcoded `TILE_GROUPS` from `TilePlacerWindow.tsx` — now derived from backend data via `useMemo`

Adding a new tile type now only requires one entry in `PlaceableTileTypes` in `board.go`.

Closes #294

## Test plan
- [ ] Run `make test` — backend compiles and tests pass
- [ ] Start game via `make run`, open tile placer window — verify all tile groups appear
- [ ] Add a test entry to `PlaceableTileTypes`, run `make generate` — confirm it auto-appears in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)