### PR TITLE
feat: per-player milestone & award progress in popovers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ frontend:
 	cd frontend && npm start
 
 backend:
-	@echo "🚀 Starting backend server..."
-	cd backend && TM_REPO_PATH=../ go run cmd/server/main.go
+	@echo "🔄 Starting backend server with hot reload..."
+	@echo "   Watching for changes in backend/ directory"
+	cd backend && TM_REPO_PATH=../ $(shell go env GOPATH)/bin/air
 
 backend-live:
 	@echo "🔄 Starting backend server with hot reload..."

--- a/backend/internal/delivery/dto/game_dto.go
+++ b/backend/internal/delivery/dto/game_dto.go
@@ -736,22 +736,25 @@ type BoardDto struct {
 
 // MilestoneDto represents a milestone for client consumption
 type MilestoneDto struct {
-	Type        string  `json:"type" ts:"string"`
-	Name        string  `json:"name" ts:"string"`
-	Description string  `json:"description" ts:"string"`
-	IsClaimed   bool    `json:"isClaimed" ts:"boolean"`
-	ClaimedBy   *string `json:"claimedBy" ts:"string | null"`
-	ClaimCost   int     `json:"claimCost" ts:"number"`
+	Type           string         `json:"type" ts:"string"`
+	Name           string         `json:"name" ts:"string"`
+	Description    string         `json:"description" ts:"string"`
+	IsClaimed      bool           `json:"isClaimed" ts:"boolean"`
+	ClaimedBy      *string        `json:"claimedBy" ts:"string | null"`
+	ClaimCost      int            `json:"claimCost" ts:"number"`
+	Required       int            `json:"required" ts:"number"`
+	PlayerProgress map[string]int `json:"playerProgress" ts:"Record<string, number>"`
 }
 
 // AwardDto represents an award for client consumption
 type AwardDto struct {
-	Type        string  `json:"type" ts:"string"`
-	Name        string  `json:"name" ts:"string"`
-	Description string  `json:"description" ts:"string"`
-	IsFunded    bool    `json:"isFunded" ts:"boolean"`
-	FundedBy    *string `json:"fundedBy" ts:"string | null"`
-	FundingCost int     `json:"fundingCost" ts:"number"`
+	Type           string         `json:"type" ts:"string"`
+	Name           string         `json:"name" ts:"string"`
+	Description    string         `json:"description" ts:"string"`
+	IsFunded       bool           `json:"isFunded" ts:"boolean"`
+	FundedBy       *string        `json:"fundedBy" ts:"string | null"`
+	FundingCost    int            `json:"fundingCost" ts:"number"`
+	PlayerProgress map[string]int `json:"playerProgress" ts:"Record<string, number>"`
 }
 
 // AwardResultDto represents the placement results for a single funded award

--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -128,8 +128,8 @@ func ToGameDto(g *game.Game, cardRegistry cards.CardRegistry, playerID string) G
 			Tiles: tileDtos,
 		},
 		PaymentConstants:   paymentConstants,
-		Milestones:         ToMilestonesDto(g.Milestones()),
-		Awards:             ToAwardsDto(g.Awards()),
+		Milestones:         ToMilestonesDto(g, cardRegistry),
+		Awards:             ToAwardsDto(g, cardRegistry),
 		AwardResults:       ToAwardResultsDto(g, cardRegistry),
 		FinalScores:        finalScoreDtos,
 		TriggeredEffects:   triggeredEffectDtos,
@@ -172,14 +172,17 @@ func convertTileBonuses(bonuses []board.TileBonus) []TileBonusDto {
 	return dtos
 }
 
-// ToMilestonesDto converts all milestones to DTOs including claim status
-func ToMilestonesDto(milestones *game.Milestones) []MilestoneDto {
+// ToMilestonesDto converts all milestones to DTOs including claim status and per-player progress
+func ToMilestonesDto(g *game.Game, cardRegistry cards.CardRegistry) []MilestoneDto {
+	milestones := g.Milestones()
+	players := g.GetAllPlayers()
+	b := g.Board()
+
 	dtos := make([]MilestoneDto, len(game.AllMilestones))
 	for i, info := range game.AllMilestones {
 		var claimedBy *string
 		isClaimed := milestones.IsClaimed(info.Type)
 		if isClaimed {
-			// Find who claimed it
 			for _, claimed := range milestones.ClaimedMilestones() {
 				if claimed.Type == info.Type {
 					claimedBy = &claimed.PlayerID
@@ -187,30 +190,41 @@ func ToMilestonesDto(milestones *game.Milestones) []MilestoneDto {
 				}
 			}
 		}
+
+		playerProgress := make(map[string]int, len(players))
+		for _, p := range players {
+			playerProgress[p.ID()] = gamecards.GetPlayerMilestoneProgress(info.Type, p, b, cardRegistry)
+		}
+
 		dtos[i] = MilestoneDto{
-			Type:        string(info.Type),
-			Name:        info.Name,
-			Description: info.Description,
-			IsClaimed:   isClaimed,
-			ClaimedBy:   claimedBy,
-			ClaimCost:   game.MilestoneClaimCost,
+			Type:           string(info.Type),
+			Name:           info.Name,
+			Description:    info.Description,
+			IsClaimed:      isClaimed,
+			ClaimedBy:      claimedBy,
+			ClaimCost:      game.MilestoneClaimCost,
+			Required:       info.Requirement,
+			PlayerProgress: playerProgress,
 		}
 	}
 	return dtos
 }
 
-// ToAwardsDto converts all awards to DTOs including funding status
-func ToAwardsDto(awards *game.Awards) []AwardDto {
+// ToAwardsDto converts all awards to DTOs including funding status and per-player scores
+func ToAwardsDto(g *game.Game, cardRegistry cards.CardRegistry) []AwardDto {
+	awards := g.Awards()
+	players := g.GetAllPlayers()
+	b := g.Board()
+
 	dtos := make([]AwardDto, len(game.AllAwards))
 	fundedCount := awards.FundedCount()
 
 	for i, info := range game.AllAwards {
 		var fundedBy *string
 		isFunded := awards.IsFunded(info.Type)
-		fundingCost := game.AwardFundingCosts[0] // Default cost for first award
+		fundingCost := game.AwardFundingCosts[0]
 
 		if isFunded {
-			// Find who funded it and what the cost was
 			for _, funded := range awards.FundedAwards() {
 				if funded.Type == info.Type {
 					fundedBy = &funded.FundedByPlayer
@@ -219,19 +233,24 @@ func ToAwardsDto(awards *game.Awards) []AwardDto {
 				}
 			}
 		} else {
-			// Calculate cost for next award
 			if fundedCount < game.MaxFundedAwards {
 				fundingCost = game.AwardFundingCosts[fundedCount]
 			}
 		}
 
+		playerProgress := make(map[string]int, len(players))
+		for _, p := range players {
+			playerProgress[p.ID()] = gamecards.CalculateAwardScore(info.Type, p, b, cardRegistry)
+		}
+
 		dtos[i] = AwardDto{
-			Type:        string(info.Type),
-			Name:        info.Name,
-			Description: info.Description,
-			IsFunded:    isFunded,
-			FundedBy:    fundedBy,
-			FundingCost: fundingCost,
+			Type:           string(info.Type),
+			Name:           info.Name,
+			Description:    info.Description,
+			IsFunded:       isFunded,
+			FundedBy:       fundedBy,
+			FundingCost:    fundingCost,
+			PlayerProgress: playerProgress,
 		}
 	}
 	return dtos

--- a/frontend/src/components/ui/popover/AwardPopover.tsx
+++ b/frontend/src/components/ui/popover/AwardPopover.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   GameDto,
   GameStatusActive,
@@ -18,6 +18,12 @@ interface AwardPopoverProps {
   anchorRef: React.RefObject<HTMLButtonElement | null>;
 }
 
+interface PlayerInfo {
+  id: string;
+  name: string;
+  color: string;
+}
+
 const AwardPopover: React.FC<AwardPopoverProps> = ({
   isVisible,
   onClose,
@@ -31,13 +37,27 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
     isGameActive && isActionPhase && isCurrentPlayerTurn && canPerformActions(gameState);
 
   const awards = gameState?.currentPlayer?.awards ?? [];
+  const globalAwards = gameState?.awards ?? [];
   const fundedCount = awards.filter((a) => a.isFunded).length;
 
+  const allPlayers: PlayerInfo[] = useMemo(() => {
+    if (!gameState) return [];
+    const players: PlayerInfo[] = [
+      {
+        id: gameState.currentPlayer.id,
+        name: gameState.currentPlayer.name,
+        color: gameState.currentPlayer.color,
+      },
+    ];
+    for (const p of gameState.otherPlayers) {
+      players.push({ id: p.id, name: p.name, color: p.color });
+    }
+    return players;
+  }, [gameState]);
+
   const getPlayerName = (playerId: string | undefined): string => {
-    if (!playerId || !gameState) return "Unknown";
-    if (playerId === gameState.currentPlayer.id) return gameState.currentPlayer.name;
-    const otherPlayer = gameState.otherPlayers.find((p) => p.id === playerId);
-    return otherPlayer?.name ?? "Unknown";
+    if (!playerId) return "Unknown";
+    return allPlayers.find((p) => p.id === playerId)?.name ?? "Unknown";
   };
 
   const handleFundAward = (awardId: string) => {
@@ -66,6 +86,13 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
           const isFunded = award.isFunded;
           const isAvailable = award.available && !isFunded;
           const isExecutable = canFundAwards && isAvailable;
+
+          const globalData = globalAwards.find((a) => a.type === award.type);
+          const playerProgress = globalData?.playerProgress ?? {};
+
+          const sortedPlayers = [...allPlayers].sort(
+            (a, b) => (playerProgress[b.id] ?? 0) - (playerProgress[a.id] ?? 0),
+          );
 
           const getState = () => {
             if (isFunded) return "claimed" as const;
@@ -136,6 +163,24 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
                     Funded by {getPlayerName(award.fundedBy)}
                   </div>
                 )}
+
+                <div className="mt-2 space-y-1">
+                  {sortedPlayers.map((player) => {
+                    const score = playerProgress[player.id] ?? 0;
+                    return (
+                      <div key={player.id} className="flex items-center gap-2 text-xs">
+                        <span
+                          className="w-2 h-2 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: player.color }}
+                        />
+                        <span className="text-white/80 truncate min-w-0">{player.name}</span>
+                        <span className="ml-auto font-orbitron font-semibold text-white/50">
+                          {score}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </GamePopoverItem>
           );

--- a/frontend/src/components/ui/popover/MilestonePopover.tsx
+++ b/frontend/src/components/ui/popover/MilestonePopover.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   GameDto,
   GameStatusActive,
@@ -18,6 +18,12 @@ interface MilestonePopoverProps {
   anchorRef: React.RefObject<HTMLButtonElement | null>;
 }
 
+interface PlayerInfo {
+  id: string;
+  name: string;
+  color: string;
+}
+
 const MilestonePopover: React.FC<MilestonePopoverProps> = ({
   isVisible,
   onClose,
@@ -31,13 +37,27 @@ const MilestonePopover: React.FC<MilestonePopoverProps> = ({
     isGameActive && isActionPhase && isCurrentPlayerTurn && canPerformActions(gameState);
 
   const milestones = gameState?.currentPlayer?.milestones ?? [];
+  const globalMilestones = gameState?.milestones ?? [];
   const claimedCount = milestones.filter((m) => m.isClaimed).length;
 
+  const allPlayers: PlayerInfo[] = useMemo(() => {
+    if (!gameState) return [];
+    const players: PlayerInfo[] = [
+      {
+        id: gameState.currentPlayer.id,
+        name: gameState.currentPlayer.name,
+        color: gameState.currentPlayer.color,
+      },
+    ];
+    for (const p of gameState.otherPlayers) {
+      players.push({ id: p.id, name: p.name, color: p.color });
+    }
+    return players;
+  }, [gameState]);
+
   const getPlayerName = (playerId: string | undefined): string => {
-    if (!playerId || !gameState) return "Unknown";
-    if (playerId === gameState.currentPlayer.id) return gameState.currentPlayer.name;
-    const otherPlayer = gameState.otherPlayers.find((p) => p.id === playerId);
-    return otherPlayer?.name ?? "Unknown";
+    if (!playerId) return "Unknown";
+    return allPlayers.find((p) => p.id === playerId)?.name ?? "Unknown";
   };
 
   const handleClaimMilestone = (milestoneId: string) => {
@@ -66,10 +86,14 @@ const MilestonePopover: React.FC<MilestonePopoverProps> = ({
           const isClaimed = milestone.isClaimed;
           const isAvailable = milestone.available && !isClaimed;
           const isExecutable = canClaimMilestones && isAvailable;
-          const progressMet =
-            milestone.progress !== undefined &&
-            milestone.required !== undefined &&
-            milestone.progress >= milestone.required;
+
+          const globalData = globalMilestones.find((m) => m.type === milestone.type);
+          const playerProgress = globalData?.playerProgress ?? {};
+          const required = globalData?.required ?? 0;
+
+          const sortedPlayers = [...allPlayers].sort(
+            (a, b) => (playerProgress[b.id] ?? 0) - (playerProgress[a.id] ?? 0),
+          );
 
           const getState = () => {
             if (isClaimed) return "claimed" as const;
@@ -109,27 +133,6 @@ const MilestonePopover: React.FC<MilestonePopoverProps> = ({
                       <span className="text-white/60 text-xs">→</span>
                       <span className="text-amber-400 text-xs font-semibold">5 VP</span>
                     </div>
-
-                    {milestone.progress !== undefined &&
-                      milestone.required !== undefined &&
-                      !isClaimed && (
-                        <div className="mt-2">
-                          <div className="flex justify-between text-xs mb-1">
-                            <span className={progressMet ? "text-green-400" : "text-amber-400"}>
-                              Progress: {milestone.progress}/{milestone.required}
-                            </span>
-                            {progressMet && <span className="text-green-400">Ready!</span>}
-                          </div>
-                          <div className="h-1.5 bg-black/40 rounded-full overflow-hidden">
-                            <div
-                              className={`h-full rounded-full transition-all ${progressMet ? "bg-green-500" : "bg-amber-500"}`}
-                              style={{
-                                width: `${Math.min(100, (milestone.progress / milestone.required) * 100)}%`,
-                              }}
-                            />
-                          </div>
-                        </div>
-                      )}
                   </div>
 
                   {canClaimMilestones && !isClaimed && (
@@ -157,6 +160,29 @@ const MilestonePopover: React.FC<MilestonePopoverProps> = ({
                 {isClaimed && milestone.claimedBy && (
                   <div className="mt-2 text-xs text-blue-400/80 italic">
                     Claimed by {getPlayerName(milestone.claimedBy)}
+                  </div>
+                )}
+
+                {!isClaimed && required > 0 && (
+                  <div className="mt-2 space-y-1">
+                    {sortedPlayers.map((player) => {
+                      const progress = playerProgress[player.id] ?? 0;
+                      const met = progress >= required;
+                      return (
+                        <div key={player.id} className="flex items-center gap-2 text-xs">
+                          <span
+                            className="w-2 h-2 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: player.color }}
+                          />
+                          <span className="text-white/80 truncate min-w-0">{player.name}</span>
+                          <span
+                            className={`ml-auto font-orbitron font-semibold ${met ? "text-green-400" : "text-white/50"}`}
+                          >
+                            {progress}/{required}
+                          </span>
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/frontend/src/types/generated/api-types.ts
+++ b/frontend/src/types/generated/api-types.ts
@@ -1046,6 +1046,8 @@ export interface MilestoneDto {
   isClaimed: boolean;
   claimedBy?: string;
   claimCost: number /* int */;
+  required: number /* int */;
+  playerProgress: { [key: string]: number /* int */ };
 }
 /**
  * AwardDto represents an award for client consumption
@@ -1057,6 +1059,7 @@ export interface AwardDto {
   isFunded: boolean;
   fundedBy?: string;
   fundingCost: number /* int */;
+  playerProgress: { [key: string]: number /* int */ };
 }
 /**
  * AwardResultDto represents the placement results for a single funded award


### PR DESCRIPTION
## Summary
- Add `playerProgress` (map of playerID → score/progress) and `required` to `MilestoneDto` and `AwardDto` in the backend
- Update `ToMilestonesDto` and `ToAwardsDto` mappers to compute per-player progress using existing `GetPlayerMilestoneProgress` and `CalculateAwardScore` functions
- Milestone popover now shows all players' progress sorted by highest, with green text when requirement is met
- Award popover now shows all players' scores sorted by highest
- Switch `make backend` to use Air hot reload (matching `make run` behavior)

## Test plan
- [x] `make test` — all backend tests pass
- [x] `make prepare-for-commit` — formatting, linting, type checking all pass
- [ ] Create a multiplayer game and verify milestone popover shows all players' progress
- [ ] Verify award popover shows all players' scores
- [ ] Verify claimed milestones and funded awards still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)