### PR TITLE
feat: combine starting card selection into single screen

### DIFF
--- a/frontend/src/components/ui/overlay/StartingCardSelectionOverlay.tsx
+++ b/frontend/src/components/ui/overlay/StartingCardSelectionOverlay.tsx
@@ -33,7 +33,6 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
   onSelectCards,
 }) => {
   const [selectedCorporationId, setSelectedCorporationId] = useState<string | null>(null);
-  const [currentStep, setCurrentStep] = useState<"corporation" | "cards">("corporation");
 
   const {
     selectedCardIds,
@@ -44,17 +43,15 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
     handleConfirm: handleCardConfirm,
   } = useCardSelection({
     cards,
-    isOpen: isOpen && currentStep === "cards",
+    isOpen,
     playerCredits,
     costPerCard: 3,
     minCards: 0,
   });
 
-  // Initialize selection when overlay opens
   useEffect(() => {
     if (isOpen && cards.length > 0) {
       setSelectedCorporationId(null);
-      setCurrentStep("corporation");
     }
   }, [isOpen, cards]);
 
@@ -64,19 +61,7 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
     setSelectedCorporationId(corporationId);
   };
 
-  const handleNextToCorporation = () => {
-    setCurrentStep("corporation");
-  };
-
-  const handleNextToCards = () => {
-    if (!selectedCorporationId) {
-      return;
-    }
-    setCurrentStep("cards");
-  };
-
   const handleConfirm = () => {
-    // Must select a corporation before confirming
     if (!selectedCorporationId) {
       return;
     }
@@ -89,72 +74,71 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
   return (
     <div className="fixed inset-0 z-[1000] flex items-center justify-center animate-[fadeIn_0.3s_ease]">
       <MainMenuSettingsButton />
-      {/* Content container */}
       <div className={OVERLAY_CONTAINER_CLASS}>
-        {/* Header */}
         <div className={OVERLAY_HEADER_CLASS}>
-          <h2 className={OVERLAY_TITLE_CLASS}>
-            {currentStep === "corporation" ? "Select Your Corporation" : "Select Starting Cards"}
-          </h2>
+          <h2 className={OVERLAY_TITLE_CLASS}>Select Starting Cards</h2>
           <p className={OVERLAY_DESCRIPTION_CLASS}>
-            {currentStep === "corporation"
-              ? "Choose your corporation to begin the game"
-              : "Choose your starting cards. Each card costs 3 MC."}
+            Choose your corporation and starting project cards. Each project card costs 3 MC.
           </p>
         </div>
 
-        {/* Step 1: Corporation Selection */}
-        {currentStep === "corporation" && availableCorporations.length > 0 && (
-          <div className="flex-1 overflow-y-auto p-8 bg-black/20 max-[768px]:p-5">
-            <div className="flex gap-4 justify-center flex-wrap">
-              {availableCorporations.map((corp) => (
-                <div key={corp.id} className="w-[400px] max-[768px]:w-full">
-                  <CorporationCard
-                    corporation={{
-                      id: corp.id,
-                      name: corp.name,
-                      description: corp.description,
-                      startingMegaCredits: corp.startingResources?.credits ?? 0,
-                      startingProduction: corp.startingProduction
-                        ? {
-                            credits: corp.startingProduction.credits,
-                            steel: corp.startingProduction.steel,
-                            titanium: corp.startingProduction.titanium,
-                            plants: corp.startingProduction.plants,
-                            energy: corp.startingProduction.energy,
-                            heat: corp.startingProduction.heat,
-                          }
-                        : undefined,
-                      startingResources: corp.startingResources
-                        ? {
-                            credits: corp.startingResources.credits,
-                            steel: corp.startingResources.steel,
-                            titanium: corp.startingResources.titanium,
-                            plants: corp.startingResources.plants,
-                            energy: corp.startingResources.energy,
-                            heat: corp.startingResources.heat,
-                          }
-                        : undefined,
-                      behaviors: corp.behaviors,
-                      logoPath: undefined,
-                    }}
-                    isSelected={selectedCorporationId === corp.id}
-                    onSelect={handleCorporationSelect}
-                    borderColor={getCorporationBorderColor(corp.name)}
-                  />
-                </div>
-              ))}
+        <div className="flex-1 overflow-y-auto p-8 bg-black/20 max-[768px]:p-5">
+          {availableCorporations.length > 0 && (
+            <div>
+              <h3 className="text-white/60 text-sm font-orbitron font-bold uppercase tracking-widest mb-4">
+                Corporation
+              </h3>
+              <div className="flex gap-4 justify-center flex-wrap">
+                {availableCorporations.map((corp) => (
+                  <div key={corp.id} className="w-[400px] max-[768px]:w-full">
+                    <CorporationCard
+                      corporation={{
+                        id: corp.id,
+                        name: corp.name,
+                        description: corp.description,
+                        startingMegaCredits: corp.startingResources?.credits ?? 0,
+                        startingProduction: corp.startingProduction
+                          ? {
+                              credits: corp.startingProduction.credits,
+                              steel: corp.startingProduction.steel,
+                              titanium: corp.startingProduction.titanium,
+                              plants: corp.startingProduction.plants,
+                              energy: corp.startingProduction.energy,
+                              heat: corp.startingProduction.heat,
+                            }
+                          : undefined,
+                        startingResources: corp.startingResources
+                          ? {
+                              credits: corp.startingResources.credits,
+                              steel: corp.startingResources.steel,
+                              titanium: corp.startingResources.titanium,
+                              plants: corp.startingResources.plants,
+                              energy: corp.startingResources.energy,
+                              heat: corp.startingResources.heat,
+                            }
+                          : undefined,
+                        behaviors: corp.behaviors,
+                        logoPath: undefined,
+                      }}
+                      isSelected={selectedCorporationId === corp.id}
+                      onSelect={handleCorporationSelect}
+                      borderColor={getCorporationBorderColor(corp.name)}
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Step 2: Cards Selection */}
-        {currentStep === "cards" && (
-          <div className="flex-1 overflow-x-auto overflow-y-hidden p-8 flex items-center bg-[radial-gradient(ellipse_at_center,rgba(139,69,19,0.1)_0%,transparent_70%)] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-white/5 [&::-webkit-scrollbar-track]:rounded [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb:hover]:bg-white/30 max-[768px]:p-5">
-            <div className="flex gap-6 mx-auto py-5 max-[768px]:gap-4">
+          <div className="border-t border-white/10 my-6" />
+
+          <div>
+            <h3 className="text-white/60 text-sm font-orbitron font-bold uppercase tracking-widest mb-4">
+              Project Cards
+            </h3>
+            <div className="flex gap-6 justify-center flex-wrap max-[768px]:gap-4">
               {cards.map((card, index) => {
-                const cardIndex = selectedCardIds.indexOf(card.id);
-                const isSelected = cardIndex !== -1;
+                const isSelected = selectedCardIds.includes(card.id);
 
                 return (
                   <GameCard
@@ -169,77 +153,53 @@ const StartingCardSelectionOverlay: React.FC<StartingCardSelectionOverlayProps> 
               })}
             </div>
           </div>
-        )}
+        </div>
 
-        {/* Footer with navigation buttons */}
         <div className={OVERLAY_FOOTER_CLASS}>
-          {/* Step 1: Corporation Footer */}
-          {currentStep === "corporation" && (
-            <>
-              <div className="text-sm text-white/70">
-                {selectedCorporationId ? "Corporation selected" : "Please select a corporation"}
+          <div className="flex gap-8 items-center max-[768px]:w-full max-[768px]:justify-between">
+            <div className={RESOURCE_DISPLAY_CLASS}>
+              <span className={RESOURCE_LABEL_CLASS}>Your Credits:</span>
+              <GameIcon iconType={ResourceTypeCredit} amount={playerCredits} size="large" />
+            </div>
+            <div className={RESOURCE_DISPLAY_CLASS}>
+              <span className={RESOURCE_LABEL_CLASS}>Total Cost:</span>
+              {totalCost > 0 ? (
+                <>
+                  <GameIcon iconType={ResourceTypeCredit} amount={totalCost} size="large" />
+                  <span className="text-white/70 text-sm">
+                    ({selectedCardIds.length} card
+                    {selectedCardIds.length !== 1 ? "s" : ""} selected)
+                  </span>
+                </>
+              ) : (
+                <span className="!text-[#4caf50] font-bold tracking-[1px]">FREE</span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 max-[768px]:w-full max-[768px]:flex-col max-[768px]:gap-3">
+            {!selectedCorporationId && (
+              <span className="text-sm text-white/70">Select a corporation to continue</span>
+            )}
+
+            {showConfirmation && (
+              <div className="text-sm">
+                <span className="text-[#ff9800]">
+                  Are you sure you don't want to select any cards?
+                </span>
               </div>
-              <GameMenuButton
-                variant="primary"
-                size="lg"
-                onClick={handleNextToCards}
-                disabled={!selectedCorporationId}
-                className="whitespace-nowrap max-[768px]:w-full max-[768px]:py-3 max-[768px]:px-6 max-[768px]:text-lg"
-              >
-                Next: Select Cards →
-              </GameMenuButton>
-            </>
-          )}
+            )}
 
-          {/* Step 2: Cards Footer */}
-          {currentStep === "cards" && (
-            <>
-              <div className="flex gap-8 items-center max-[768px]:w-full max-[768px]:justify-between">
-                <div className={RESOURCE_DISPLAY_CLASS}>
-                  <span className={RESOURCE_LABEL_CLASS}>Your Credits:</span>
-                  <GameIcon iconType={ResourceTypeCredit} amount={playerCredits} size="large" />
-                </div>
-                <div className={RESOURCE_DISPLAY_CLASS}>
-                  <span className={RESOURCE_LABEL_CLASS}>Total Cost:</span>
-                  {totalCost > 0 ? (
-                    <>
-                      <GameIcon iconType={ResourceTypeCredit} amount={totalCost} size="large" />
-                      <span className="text-white/70 text-sm">
-                        ({selectedCardIds.length} card
-                        {selectedCardIds.length !== 1 ? "s" : ""} selected)
-                      </span>
-                    </>
-                  ) : (
-                    <span className="!text-[#4caf50] font-bold tracking-[1px]">FREE</span>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-center gap-4 max-[768px]:w-full max-[768px]:flex-col max-[768px]:gap-3">
-                <GameMenuButton variant="text" size="md" onClick={handleNextToCorporation}>
-                  ← Back
-                </GameMenuButton>
-
-                {showConfirmation && (
-                  <div className="text-sm">
-                    <span className="text-[#ff9800]">
-                      Are you sure you don't want to select any cards?
-                    </span>
-                  </div>
-                )}
-
-                <GameMenuButton
-                  variant="primary"
-                  size="lg"
-                  onClick={handleConfirm}
-                  disabled={!isValidSelection}
-                  className="whitespace-nowrap max-[768px]:w-full max-[768px]:py-3 max-[768px]:px-6 max-[768px]:text-lg"
-                >
-                  {showConfirmation ? "Confirm Skip" : "Confirm Selection"}
-                </GameMenuButton>
-              </div>
-            </>
-          )}
+            <GameMenuButton
+              variant="primary"
+              size="lg"
+              onClick={handleConfirm}
+              disabled={!selectedCorporationId || !isValidSelection}
+              className="whitespace-nowrap max-[768px]:w-full max-[768px]:py-3 max-[768px]:px-6 max-[768px]:text-lg"
+            >
+              {showConfirmation ? "Confirm Skip" : "Confirm Selection"}
+            </GameMenuButton>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace 2-step wizard (corporation → project cards) with a single scrollable screen showing corporations and project cards together
- Players can now see all cards at once and select in any order without step navigation
- Unified footer always shows credits, cost, and a single "Confirm Selection" button (disabled until corporation is chosen)

## Test plan
- [ ] Start a game and verify the starting card selection shows corporations and project cards on one screen
- [ ] Confirm selecting/deselecting corporation and project cards works correctly
- [ ] Confirm cost updates correctly as cards are selected/deselected
- [ ] Confirm cannot confirm without a corporation selected
- [ ] Confirm 0-card confirmation flow ("Are you sure?") still works
- [ ] Verify mobile layout stacks properly at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)