### PR TITLE
fix: ocean tile tooltip bugs

### DIFF
--- a/frontend/src/components/game/board/OceanTile.tsx
+++ b/frontend/src/components/game/board/OceanTile.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useRef, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
-import { panState } from "../controls/PanControls";
 import { useWorld3DSettings } from "../../../contexts/World3DSettingsContext";
 import { useTextures } from "../../../hooks/useTextures";
 import { sphereProjectionVertex, oceanBorderFragment, createOceanMaterial } from "./shaders";
@@ -13,23 +12,9 @@ interface OceanTileProps {
   overlayGeometry: THREE.BufferGeometry;
   isOceanSpace: boolean;
   tileType: string;
-  onClick: () => void;
-  onHoverChange: (hovered: boolean) => void;
-  onPointerEnterCapture?: (event: THREE.Event & { nativeEvent: PointerEvent }) => void;
-  onPointerMoveCapture?: (event: THREE.Event & { nativeEvent: PointerEvent }) => void;
-  onPointerLeaveCapture?: () => void;
 }
 
-export default function OceanTile({
-  overlayGeometry,
-  isOceanSpace,
-  tileType,
-  onClick,
-  onHoverChange,
-  onPointerEnterCapture,
-  onPointerMoveCapture,
-  onPointerLeaveCapture,
-}: OceanTileProps) {
+export default function OceanTile({ overlayGeometry, isOceanSpace, tileType }: OceanTileProps) {
   const { camera } = useThree();
   const { settings: world3DSettings } = useWorld3DSettings();
 
@@ -188,26 +173,7 @@ export default function OceanTile({
           geometry={oceanWaterGeometry}
           material={oceanWaterMaterial}
           renderOrder={12}
-          onPointerEnter={(event: any) => {
-            if (!panState.isPanning) {
-              onHoverChange(true);
-              onPointerEnterCapture?.(event);
-            }
-          }}
-          onPointerMove={(event: any) => {
-            if (!panState.isPanning) {
-              onPointerMoveCapture?.(event);
-            }
-          }}
-          onPointerLeave={() => {
-            onHoverChange(false);
-            onPointerLeaveCapture?.();
-          }}
-          onClick={(event) => {
-            if (panState.isPanning) return;
-            event.stopPropagation();
-            onClick();
-          }}
+          raycast={() => {}}
         />
       )}
     </>

--- a/frontend/src/components/game/board/Tile.tsx
+++ b/frontend/src/components/game/board/Tile.tsx
@@ -535,6 +535,7 @@ export default function Tile({
       transparent: true,
       opacity:
         isGreenery ||
+        tileType === "ocean" ||
         tileType === "city" ||
         tileType === "volcano" ||
         tileType === "nuclear-zone" ||
@@ -636,50 +637,48 @@ export default function Tile({
       quaternion={surfaceQuaternion}
       scale={[entranceScale, entranceScale, entranceScale]}
     >
-      {/* Main hex tile - hidden for ocean (water mesh handles rendering) */}
-      {tileType !== "ocean" && (
-        <mesh
-          ref={meshRef}
-          geometry={hexGeometry}
-          material={hexTileMaterial}
-          renderOrder={10}
-          onPointerEnter={(event) => {
-            if (!panState.isPanning) {
-              setHovered(true);
-              if (isAvailableForPlacement) {
-                hoverSound.onMouseEnter?.();
-              }
-              onHoverInfo?.({
-                position: { x: event.nativeEvent.clientX, y: event.nativeEvent.clientY },
-                tileType,
-                displayName,
-                ownerId: ownerId || null,
-                reservedById: reservedById || null,
-                isOceanSpace,
-                isVolcanic,
-                bonuses,
-              });
-            }
-          }}
-          onPointerMove={(event) => {
-            if (!panState.isPanning) {
-              onHoverMove?.({ x: event.nativeEvent.clientX, y: event.nativeEvent.clientY });
-            }
-          }}
-          onPointerLeave={() => {
-            setHovered(false);
-            onHoverLeave?.();
-          }}
-          onClick={(event) => {
-            if (panState.isPanning) return;
-            event.stopPropagation();
+      {/* Main hex tile - always rendered; invisible for ocean but still receives raycasts */}
+      <mesh
+        ref={meshRef}
+        geometry={hexGeometry}
+        material={hexTileMaterial}
+        renderOrder={10}
+        onPointerEnter={(event) => {
+          if (!panState.isPanning) {
+            setHovered(true);
             if (isAvailableForPlacement) {
-              hoverSound.onClick?.();
+              hoverSound.onMouseEnter?.();
             }
-            onClick();
-          }}
-        />
-      )}
+            onHoverInfo?.({
+              position: { x: event.nativeEvent.clientX, y: event.nativeEvent.clientY },
+              tileType,
+              displayName,
+              ownerId: ownerId || null,
+              reservedById: reservedById || null,
+              isOceanSpace,
+              isVolcanic,
+              bonuses,
+            });
+          }
+        }}
+        onPointerMove={(event) => {
+          if (!panState.isPanning) {
+            onHoverMove?.({ x: event.nativeEvent.clientX, y: event.nativeEvent.clientY });
+          }
+        }}
+        onPointerLeave={() => {
+          setHovered(false);
+          onHoverLeave?.();
+        }}
+        onClick={(event) => {
+          if (panState.isPanning) return;
+          event.stopPropagation();
+          if (isAvailableForPlacement) {
+            hoverSound.onClick?.();
+          }
+          onClick();
+        }}
+      />
 
       {/* Hex border - hidden for ocean tiles */}
       {tileType !== "ocean" && (
@@ -691,26 +690,6 @@ export default function Tile({
         overlayGeometry={overlayGeometry}
         isOceanSpace={tileData.isOceanSpace}
         tileType={tileType}
-        onClick={onClick}
-        onHoverChange={setHovered}
-        onPointerEnterCapture={(event: any) => {
-          onHoverInfo?.({
-            position: { x: event.nativeEvent.clientX, y: event.nativeEvent.clientY },
-            tileType,
-            displayName,
-            ownerId: ownerId || null,
-            reservedById: reservedById || null,
-            isOceanSpace,
-            isVolcanic,
-            bonuses,
-          });
-        }}
-        onPointerMoveCapture={(event: any) => {
-          onHoverMove?.({ x: event.nativeEvent.clientX, y: event.nativeEvent.clientY });
-        }}
-        onPointerLeaveCapture={() => {
-          onHoverLeave?.();
-        }}
       />
 
       {/* Volcanic space indicator - red tint for unoccupied volcanic tiles */}

--- a/frontend/src/components/game/board/TileGrid.tsx
+++ b/frontend/src/components/game/board/TileGrid.tsx
@@ -154,14 +154,9 @@ export default function TileGrid({
     [playerNameMap, playerColorMap],
   );
 
-  const handleTileHoverMove = useCallback(
-    (position: { x: number; y: number }) => {
-      if (tooltipData) {
-        setTooltipData((prev) => (prev ? { ...prev, position } : null));
-      }
-    },
-    [tooltipData],
-  );
+  const handleTileHoverMove = useCallback((position: { x: number; y: number }) => {
+    setTooltipData((prev) => (prev ? { ...prev, position } : null));
+  }, []);
 
   const handleTileHoverLeave = useCallback(() => {
     if (hoverTimerRef.current) {

--- a/frontend/src/components/ui/display/TileTooltip.tsx
+++ b/frontend/src/components/ui/display/TileTooltip.tsx
@@ -49,7 +49,7 @@ const TileTooltip: React.FC<{ data: TileTooltipData | null }> = ({ data }) => {
         }}
       >
         <div className="font-orbitron font-bold text-xs text-white mb-1">
-          {isEmptySpace ? spaceLabel : label}
+          {isEmptySpace && !data.displayName ? spaceLabel : label}
         </div>
 
         {data.isVolcanic && isEmptySpace && (


### PR DESCRIPTION
## Summary

- **Always render hex mesh for ocean tiles** (invisible at opacity 0) so it serves as the consistent raycast target, fixing tooltips not showing on placed ocean tiles
- **Disable raycasting on ocean water mesh** (`raycast={() => {}}`) — the oversized circular geometry (radius 0.216 vs hex 0.166) was overlapping adjacent tiles and blocking their pointer events, causing multi-second tooltip delays
- **Fix `handleTileHoverMove` dependency** — remove `tooltipData` from the dependency array to prevent all ~61 Tile components from re-rendering on every mouse move while a tooltip is showing

## Test plan

- [ ] Place an ocean tile, hover it → tooltip shows "Ocean"
- [ ] Move cursor from ocean to adjacent land tile → tooltip appears promptly (no multi-second delay)
- [ ] Hover empty ocean space → tooltip shows "Ocean Space"
- [ ] Hover regular land tile → tooltip shows "Land Space"
- [ ] Pan the board, then hover tiles → tooltips still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)