### PR TITLE
fix: unlock audio on first user gesture for browser autoplay policy

### DIFF
--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -36,6 +36,17 @@ class AudioService {
       navigator.mediaSession.setActionHandler("nexttrack", noop);
     }
 
+    const unlockAudio = () => {
+      const ctx = new AudioContext();
+      void ctx.resume().then(() => ctx.close());
+      document.removeEventListener("click", unlockAudio);
+      document.removeEventListener("touchstart", unlockAudio);
+      document.removeEventListener("keydown", unlockAudio);
+    };
+    document.addEventListener("click", unlockAudio);
+    document.addEventListener("touchstart", unlockAudio);
+    document.addEventListener("keydown", unlockAudio);
+
     this.preloadAudioFiles();
   }
 


### PR DESCRIPTION
## Summary
- Browsers block programmatic `audio.play()` until a qualifying user gesture (click/tap/keydown) occurs on the page
- In-game sounds (temperature, oxygen, production, your-turn) are triggered from `useEffect` hooks reacting to WebSocket state changes — not user gestures — so they were silently blocked
- Added a one-time document event listener that creates/resumes an `AudioContext` on the first user interaction, satisfying the autoplay policy before the user reaches the game

## Test plan
- [ ] Start a game with `make run`, join, and verify sounds play on game state changes **without** touching volume settings
- [ ] Verify volume controls still work correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)