### PR TITLE
fix: implement ocean-placed passive effect trigger

### DIFF
--- a/backend/internal/action/passive_effect_subscriber.go
+++ b/backend/internal/action/passive_effect_subscriber.go
@@ -44,6 +44,11 @@ func SubscribePassiveEffectToEvents(
 			subID = subscribeCityPlacedEffect(ctx, g, p, effect, trigger, log, cr)
 		}
 
+		// Handle ocean-placed trigger
+		if trigger.Condition.Type == "ocean-placed" {
+			subID = subscribeOceanPlacedEffect(ctx, g, p, effect, trigger, log, cr)
+		}
+
 		// Handle tag-played trigger
 		if trigger.Condition.Type == "tag-played" {
 			subID = subscribeTagPlayedEffect(ctx, g, p, effect, trigger, log, cr)
@@ -202,6 +207,66 @@ func subscribeCityPlacedEffect(
 	})
 
 	log.Debug("📬 Subscribed passive effect to TilePlacedEvent (city)",
+		zap.String("card_name", effect.CardName))
+
+	return subID
+}
+
+// subscribeOceanPlacedEffect subscribes to TilePlacedEvent for ocean placements
+func subscribeOceanPlacedEffect(
+	_ context.Context,
+	g *game.Game,
+	p *player.Player,
+	effect player.CardEffect,
+	trigger shared.Trigger,
+	log *zap.Logger,
+	cr gamecards.CardRegistryInterface,
+) events.SubscriptionID {
+	subID := events.Subscribe(g.EventBus(), func(event events.TilePlacedEvent) {
+		if event.GameID != g.ID() {
+			return
+		}
+
+		if event.TileType != string(shared.ResourceOceanTile) {
+			return
+		}
+
+		target := "self-player"
+		if trigger.Condition.Target != nil {
+			target = *trigger.Condition.Target
+		}
+
+		if target == "self-player" && event.PlayerID != p.ID() {
+			return
+		}
+
+		location := "anywhere"
+		if trigger.Condition.Location != nil {
+			location = *trigger.Condition.Location
+		}
+
+		if location != "anywhere" && location != "mars" {
+			return
+		}
+
+		log.Info("🎴 Passive effect triggered (ocean placement)",
+			zap.String("card_name", effect.CardName),
+			zap.String("player_id", p.ID()),
+			zap.String("placed_by", event.PlayerID),
+			zap.String("tile_type", event.TileType))
+
+		applier := gamecards.NewBehaviorApplier(p, g, effect.CardName, log).
+			WithSourceCardID(effect.CardID).
+			WithCardRegistry(cr).
+			WithSourceType(game.SourceTypePassiveEffect)
+		if err := applier.ApplyOutputs(context.Background(), effect.Behavior.Outputs); err != nil {
+			log.Error("Failed to apply passive effect outputs",
+				zap.String("card_name", effect.CardName),
+				zap.Error(err))
+		}
+	})
+
+	log.Debug("📬 Subscribed passive effect to TilePlacedEvent (ocean)",
 		zap.String("card_name", effect.CardName))
 
 	return subID

--- a/backend/test/action/card_effects/passive_card_effects_test.go
+++ b/backend/test/action/card_effects/passive_card_effects_test.go
@@ -489,3 +489,183 @@ func TestViralEnhancers_DoesNotTriggerOnBuildingTag(t *testing.T) {
 	testutil.AssertEqual(t, plantsBefore, plantsAfter,
 		"Viral Enhancers should NOT trigger on building tag")
 }
+
+// --- Arctic Algae (023) ---
+// "Effect: When anyone places an ocean tile, gain 2 plants."
+
+func TestArcticAlgae_GainPlantsOnAnyOceanPlacement(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	arcticAlgaeCard := gamecards.Card{
+		ID:   "card-arctic-algae",
+		Name: "Arctic Algae",
+		Type: gamecards.CardTypeActive,
+		Cost: 12,
+		Tags: []shared.CardTag{shared.TagPlant},
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{arcticAlgaeCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	other := players[1]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	other.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	effect := player.CardEffect{
+		CardID:        "card-arctic-algae",
+		CardName:      "Arctic Algae",
+		BehaviorIndex: 0,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:   "ocean-placed",
+						Target: &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourcePlant, Amount: 2, Target: "self-player"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	plantsBefore := owner.Resources().Get().Plants
+
+	// Another player places an ocean tile
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: other.ID(),
+		TileType: string(shared.ResourceOceanTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	plantsAfter := owner.Resources().Get().Plants
+	testutil.AssertEqual(t, plantsBefore+2, plantsAfter,
+		"Arctic Algae owner should gain 2 plants when any player places an ocean")
+}
+
+func TestArcticAlgae_TriggersOnSelfOceanToo(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	arcticAlgaeCard := gamecards.Card{
+		ID:   "card-arctic-algae",
+		Name: "Arctic Algae",
+		Type: gamecards.CardTypeActive,
+		Cost: 12,
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{arcticAlgaeCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	effect := player.CardEffect{
+		CardID:        "card-arctic-algae",
+		CardName:      "Arctic Algae",
+		BehaviorIndex: 0,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:   "ocean-placed",
+						Target: &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourcePlant, Amount: 2, Target: "self-player"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	plantsBefore := owner.Resources().Get().Plants
+
+	// Owner places an ocean tile
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: owner.ID(),
+		TileType: string(shared.ResourceOceanTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	plantsAfter := owner.Resources().Get().Plants
+	testutil.AssertEqual(t, plantsBefore+2, plantsAfter,
+		"Arctic Algae should also trigger when owner places an ocean")
+}
+
+func TestArcticAlgae_DoesNotTriggerOnCityPlacement(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	arcticAlgaeCard := gamecards.Card{
+		ID:   "card-arctic-algae",
+		Name: "Arctic Algae",
+		Type: gamecards.CardTypeActive,
+		Cost: 12,
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{arcticAlgaeCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	effect := player.CardEffect{
+		CardID:        "card-arctic-algae",
+		CardName:      "Arctic Algae",
+		BehaviorIndex: 0,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:   "ocean-placed",
+						Target: &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourcePlant, Amount: 2, Target: "self-player"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	plantsBefore := owner.Resources().Get().Plants
+
+	// Place a city (not an ocean)
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: owner.ID(),
+		TileType: string(shared.ResourceCityTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	plantsAfter := owner.Resources().Get().Plants
+	testutil.AssertEqual(t, plantsBefore, plantsAfter,
+		"Arctic Algae should NOT trigger on city placement")
+}


### PR DESCRIPTION
## Summary
- Add `subscribeOceanPlacedEffect` handler in `passive_effect_subscriber.go` that subscribes to `TilePlacedEvent` and filters for ocean tiles, following the same pattern as `subscribeCityPlacedEffect`
- Register the handler for the `"ocean-placed"` trigger type in `SubscribePassiveEffectToEvents`
- Cards like Arctic Algae ("When anyone places an ocean tile, gain 2 plants") now correctly fire their passive effects

## Test plan
- [x] `TestArcticAlgae_GainPlantsOnAnyOceanPlacement` — another player places ocean, owner gains 2 plants
- [x] `TestArcticAlgae_TriggersOnSelfOceanToo` — owner places ocean, still gains 2 plants
- [x] `TestArcticAlgae_DoesNotTriggerOnCityPlacement` — city placement doesn't trigger the effect
- [ ] Manual: play Arctic Algae, place an ocean tile, verify +2 plants

🤖 Generated with [Claude Code](https://claude.com/claude-code)