### PR TITLE
fix: remove duplicate ocean placement sound

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -77,7 +77,6 @@ export default function GameInterface() {
   const {
     playProductionSound,
     playTemperatureSound,
-    playWaterPlacementSound,
     playOxygenSound,
     playAsteroidImpactSound,
     playYourTurnSound,
@@ -307,13 +306,6 @@ export default function GameInterface() {
           void playTemperatureSound();
         }
 
-        // Play water placement sound when ocean count increases
-        const prevOceans = previousGameRef.current.globalParameters?.oceans;
-        const newOceans = updatedGame.globalParameters?.oceans;
-        if (prevOceans !== undefined && newOceans !== undefined && newOceans > prevOceans) {
-          void playWaterPlacementSound();
-        }
-
         // Play oxygen increase sound when oxygen goes up
         const prevOxygen = previousGameRef.current.globalParameters?.oxygen;
         const newOxygen = updatedGame.globalParameters?.oxygen;
@@ -371,13 +363,7 @@ export default function GameInterface() {
         setShowCorporationModal(false);
       }
     },
-    [
-      isReconnecting,
-      playTemperatureSound,
-      playWaterPlacementSound,
-      playOxygenSound,
-      playYourTurnSound,
-    ],
+    [isReconnecting, playTemperatureSound, playOxygenSound, playYourTurnSound],
   );
 
   const handleLogUpdate = useCallback(


### PR DESCRIPTION
## Summary
- Ocean placement sound was playing twice — once from `TileGrid` (tile detection) and once from `GameInterface` (ocean count change)
- Removed the redundant `GameInterface` trigger since `TileGrid` already handles ocean tile sounds

## Test plan
- [ ] Place an ocean tile and verify the sound plays exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)