### PR TITLE
Add Raspberry Pi deploy script

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -1,0 +1,70 @@
+name: Deploy to Raspberry Pi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build backend (linux/arm64)
+        working-directory: backend
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o bin/server-arm64 cmd/server/main.go
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pi-deploy
+          path: |
+            backend/bin/server-arm64
+            backend/assets/terraforming_mars_cards.json
+            frontend/build/
+            frontend/nginx.conf
+            frontend/docker-entrypoint.sh
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: raspberry-pi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pi-deploy
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PI_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ssh.mh-hemma.rackaracka.net >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy to Pi
+        run: |
+          chmod +x scripts/deploy-pi.sh
+          chmod +x backend/bin/server-arm64
+          SKIP_BUILD=1 ./scripts/deploy-pi.sh

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ __pycache__/
 
 # Playwright
 .playwright-cli
+
+# Deploy
+.deploy-staging/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Terraforming Mars - Unified Development Makefile
 # Run from project root directory
 
-.PHONY: help run frontend backend backend-live kill lint typecheck test test-backend test-frontend test-verbose test-coverage clean build format format-backend format-frontend install-cli generate prepare-for-commit
+.PHONY: help run frontend backend backend-live kill lint typecheck test test-backend test-frontend test-verbose test-coverage clean build format format-backend format-frontend install-cli generate prepare-for-commit deploy-pi
 
 # Default target - show help
 help:
@@ -166,6 +166,10 @@ generate:
 	@echo "🔄 Generating TypeScript types from Go structs..."
 	cd backend && tygo generate
 	@echo "✅ TypeScript types generated"
+
+# Raspberry Pi deployment
+deploy-pi:
+	./scripts/deploy-pi.sh
 
 # Watch for changes (requires entr: apt install entr)
 test-watch:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Digital implementation of the Terraforming Mars board game with real-time multiplayer" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Terraforming Mars 2</title>
+    <title>Terraforming Mars CE</title>
   </head>
   <body style="background-color: #000000; margin: 0;">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PI_HOST="${PI_HOST:-mhm@ssh.mh-hemma.rackaracka.net}"
+PI_COMPOSE_DIR="${PI_COMPOSE_DIR:-/home/mhm/terraforming-mars}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STAGING_DIR="$PROJECT_ROOT/.deploy-staging"
+
+BACKEND_IMAGE="ghcr.io/rackaracka123/terraforming-mars-backend:latest"
+FRONTEND_IMAGE="ghcr.io/rackaracka123/terraforming-mars-frontend:latest"
+
+usage() {
+    echo "Usage: $0 [--build-only]"
+    echo ""
+    echo "  (no flags)    Build and deploy to Pi via Docker"
+    echo "  --build-only  Build without deploying"
+    echo ""
+    echo "Environment variables:"
+    echo "  PI_HOST         SSH target (default: mhm@ssh.mh-hemma.rackaracka.net)"
+    echo "  PI_COMPOSE_DIR  Remote compose dir (default: /home/mhm/terraforming-mars)"
+    echo "  SKIP_BUILD=1    Skip build, deploy pre-built artifacts"
+}
+
+build() {
+    echo "==> Building backend (linux/arm64)..."
+    cd "$PROJECT_ROOT/backend"
+    CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o bin/server-arm64 cmd/server/main.go
+    echo "    backend/bin/server-arm64 ready"
+
+    echo "==> Building frontend..."
+    cd "$PROJECT_ROOT/frontend"
+    npm run build
+    echo "    frontend/build/ ready"
+}
+
+stage() {
+    echo "==> Staging deploy artifacts..."
+    rm -rf "$STAGING_DIR"
+    mkdir -p "$STAGING_DIR/backend" "$STAGING_DIR/frontend"
+
+    cp "$PROJECT_ROOT/backend/bin/server-arm64" "$STAGING_DIR/backend/server"
+    cp -r "$PROJECT_ROOT/backend/assets" "$STAGING_DIR/backend/assets"
+
+    cp -r "$PROJECT_ROOT/frontend/build" "$STAGING_DIR/frontend/build"
+    cp "$PROJECT_ROOT/frontend/nginx.conf" "$STAGING_DIR/frontend/nginx.conf"
+    cp "$PROJECT_ROOT/frontend/docker-entrypoint.sh" "$STAGING_DIR/frontend/docker-entrypoint.sh"
+
+    cat > "$STAGING_DIR/backend/Dockerfile" <<'DOCKERFILE'
+FROM alpine:latest
+WORKDIR /app
+RUN apk --no-cache add ca-certificates tzdata
+COPY server .
+COPY assets ./assets
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3001/api/health || exit 1
+CMD ["./server"]
+DOCKERFILE
+
+    cat > "$STAGING_DIR/frontend/Dockerfile" <<'DOCKERFILE'
+FROM nginx:alpine
+COPY build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]
+DOCKERFILE
+
+    echo "    staged to .deploy-staging/"
+}
+
+deploy() {
+    echo "==> Uploading to $PI_HOST..."
+    rsync -az --delete "$STAGING_DIR/" "$PI_HOST:/tmp/tm-deploy/"
+
+    echo "==> Building Docker images on Pi..."
+    ssh "$PI_HOST" bash <<REMOTE
+set -euo pipefail
+
+echo "    Building backend image..."
+docker build -t $BACKEND_IMAGE /tmp/tm-deploy/backend/
+
+echo "    Building frontend image..."
+docker build -t $FRONTEND_IMAGE /tmp/tm-deploy/frontend/
+
+echo "    Restarting containers..."
+cd $PI_COMPOSE_DIR
+docker compose up -d --force-recreate backend frontend
+
+echo "    Cleaning up..."
+rm -rf /tmp/tm-deploy
+docker image prune -f
+REMOTE
+
+    echo "==> Waiting for health checks..."
+    sleep 5
+
+    if ssh "$PI_HOST" "docker inspect tm-backend --format '{{.State.Health.Status}}'" | grep -q healthy; then
+        echo "    backend: healthy"
+    else
+        echo "    backend: waiting..."
+        sleep 10
+        ssh "$PI_HOST" "docker inspect tm-backend --format '{{.State.Health.Status}}'"
+    fi
+
+    if ssh "$PI_HOST" "docker inspect tm-frontend --format '{{.State.Health.Status}}'" | grep -q healthy; then
+        echo "    frontend: healthy"
+    else
+        echo "    frontend: waiting..."
+        sleep 10
+        ssh "$PI_HOST" "docker inspect tm-frontend --format '{{.State.Health.Status}}'"
+    fi
+
+    rm -rf "$STAGING_DIR"
+    echo "==> Deploy complete"
+}
+
+case "${1:-}" in
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    --build-only)
+        build
+        ;;
+    "")
+        if [ "$SKIP_BUILD" = "1" ]; then
+            echo "==> SKIP_BUILD=1, skipping build phase"
+        else
+            build
+        fi
+        stage
+        deploy
+        ;;
+    *)
+        echo "Unknown flag: $1"
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `scripts/deploy-pi.sh` that cross-compiles backend (arm64), builds frontend, rsyncs to Pi, builds Docker images natively, and restarts via docker-compose
- Add GitHub Actions workflow for manual deploys (`workflow_dispatch`)
- Add `make deploy-pi` Makefile target
- Update page title to "Terraforming Mars CE"

## Test plan
- [x] `make deploy-pi` — verified full build + deploy cycle
- [x] Containers recreated and healthy on Pi
- [x] Site accessible via Cloudflare tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)