### PR TITLE
test: add VP calculator and final scoring tests

### DIFF
--- a/backend/internal/delivery/dto/game_dto.go
+++ b/backend/internal/delivery/dto/game_dto.go
@@ -706,6 +706,7 @@ type OtherPlayerDto struct {
 	ResourceStorage           map[string]int                     `json:"resourceStorage" ts:"Record<string, number>"`
 	PaymentSubstitutes        []PaymentSubstituteDto             `json:"paymentSubstitutes" ts:"PaymentSubstituteDto[]"`
 	StoragePaymentSubstitutes []StoragePaymentSubstituteDto      `json:"storagePaymentSubstitutes" ts:"StoragePaymentSubstituteDto[]"`
+	VPGranters                []VPGranterDto                     `json:"vpGranters" ts:"VPGranterDto[]"`
 }
 
 // GameDto represents a game for client consumption (clean architecture)

--- a/backend/internal/delivery/dto/mapper_player.go
+++ b/backend/internal/delivery/dto/mapper_player.go
@@ -156,6 +156,7 @@ func ToOtherPlayerDto(p *player.Player, g *game.Game, cardRegistry cards.CardReg
 		ResourceStorage:           p.Resources().Storage(),
 		PaymentSubstitutes:        convertPaymentSubstitutes(p.Resources().PaymentSubstitutes()),
 		StoragePaymentSubstitutes: convertStoragePaymentSubstitutes(p.Resources().StoragePaymentSubstitutes()),
+		VPGranters:                toVPGranterDtos(p.VPGranters().GetAll()),
 	}
 }
 

--- a/backend/test/action/game/final_scoring_test.go
+++ b/backend/test/action/game/final_scoring_test.go
@@ -1,0 +1,165 @@
+package game_test
+
+import (
+	"context"
+	"testing"
+
+	gameaction "terraforming-mars-backend/internal/action/game"
+	"terraforming-mars-backend/internal/game/board"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/test/testutil"
+)
+
+// TestFinalScoring_CardVPIncluded verifies that FinalScoringAction produces
+// non-zero CardVP when players have VP-granting cards played.
+func TestFinalScoring_CardVPIncluded(t *testing.T) {
+	g, repo, cardRegistry, p1ID, p2ID := testutil.SetupTwoPlayerGame(t)
+	ctx := context.Background()
+	logger := testutil.TestLogger()
+
+	p1, _ := g.GetPlayer(p1ID)
+	p2, _ := g.GetPlayer(p2ID)
+
+	// Player 1: play Colonizer Training Camp (001) = 2 VP fixed
+	ctcID := testutil.CardID("Colonizer Training Camp")
+	p1.PlayedCards().AddCard(ctcID, "Colonizer Training Camp", "automated", []string{"building", "jovian"})
+
+	// Player 1: play Predators (024) with 4 animals = 4 VP
+	predatorsID := testutil.CardID("Predators")
+	p1.PlayedCards().AddCard(predatorsID, "Predators", "active", []string{"animal"})
+	p1.Resources().AddToStorage(predatorsID, 4)
+
+	// Player 2: play Asteroid Mining Consortium (002) = 1 VP fixed
+	amcID := testutil.CardID("Asteroid Mining Consortium")
+	p2.PlayedCards().AddCard(amcID, "Asteroid Mining Consortium", "automated", []string{"jovian"})
+
+	// Max global parameters so game can end
+	gp := g.GlobalParameters()
+	for !gp.IsMaxed() {
+		if gp.Temperature() < 8 {
+			gp.IncreaseTemperature(ctx, 1)
+		}
+		if gp.Oxygen() < 14 {
+			gp.IncreaseOxygen(ctx, 1)
+		}
+		if gp.Oceans() < 9 {
+			gp.PlaceOcean(ctx)
+		}
+	}
+
+	// Execute final scoring
+	action := gameaction.NewFinalScoringAction(repo, cardRegistry, logger)
+	err := action.Execute(ctx, g.ID())
+	if err != nil {
+		t.Fatalf("FinalScoringAction failed: %v", err)
+	}
+
+	// Check final scores
+	scores := g.GetFinalScores()
+	if scores == nil {
+		t.Fatal("Final scores are nil after FinalScoringAction")
+	}
+
+	if len(scores) != 2 {
+		t.Fatalf("Expected 2 scores, got %d", len(scores))
+	}
+
+	// Find player 1's score
+	var p1Score, p2Score *struct {
+		cardVP  int
+		totalVP int
+	}
+	for _, s := range scores {
+		if s.PlayerID == p1ID {
+			p1Score = &struct {
+				cardVP  int
+				totalVP int
+			}{s.Breakdown.CardVP, s.Breakdown.TotalVP}
+		}
+		if s.PlayerID == p2ID {
+			p2Score = &struct {
+				cardVP  int
+				totalVP int
+			}{s.Breakdown.CardVP, s.Breakdown.TotalVP}
+		}
+	}
+
+	if p1Score == nil {
+		t.Fatal("Player 1 score not found in final scores")
+	}
+	if p2Score == nil {
+		t.Fatal("Player 2 score not found in final scores")
+	}
+
+	// Player 1: Colonizer Training Camp (2) + Predators w/ 4 animals (4) = 6 card VP
+	if p1Score.cardVP != 6 {
+		t.Errorf("Player 1 CardVP: expected 6, got %d", p1Score.cardVP)
+	}
+
+	// Player 2: Asteroid Mining Consortium (1) = 1 card VP
+	if p2Score.cardVP != 1 {
+		t.Errorf("Player 2 CardVP: expected 1, got %d", p2Score.cardVP)
+	}
+
+	// Total VP should include CardVP
+	if p1Score.totalVP < p1Score.cardVP {
+		t.Errorf("Player 1 TotalVP (%d) should be >= CardVP (%d)", p1Score.totalVP, p1Score.cardVP)
+	}
+}
+
+// TestFinalScoring_GreeneryAndCityVP verifies tile VP in final scoring.
+func TestFinalScoring_GreeneryAndCityVP(t *testing.T) {
+	g, repo, cardRegistry, p1ID, _ := testutil.SetupTwoPlayerGame(t)
+	ctx := context.Background()
+	logger := testutil.TestLogger()
+
+	// Place greenery and city tiles for player 1
+	err := g.Board().UpdateTileOccupancy(ctx, shared.HexPosition{Q: 0, R: 0, S: 0}, board.TileOccupant{
+		Type: shared.ResourceGreeneryTile,
+	}, p1ID)
+	if err != nil {
+		t.Fatalf("Failed to place greenery: %v", err)
+	}
+
+	err = g.Board().UpdateTileOccupancy(ctx, shared.HexPosition{Q: 1, R: -1, S: 0}, board.TileOccupant{
+		Type: shared.ResourceCityTile,
+	}, p1ID)
+	if err != nil {
+		t.Fatalf("Failed to place city: %v", err)
+	}
+
+	// Max global parameters
+	gp := g.GlobalParameters()
+	for !gp.IsMaxed() {
+		if gp.Temperature() < 8 {
+			gp.IncreaseTemperature(ctx, 1)
+		}
+		if gp.Oxygen() < 14 {
+			gp.IncreaseOxygen(ctx, 1)
+		}
+		if gp.Oceans() < 9 {
+			gp.PlaceOcean(ctx)
+		}
+	}
+
+	action := gameaction.NewFinalScoringAction(repo, cardRegistry, logger)
+	err = action.Execute(ctx, g.ID())
+	if err != nil {
+		t.Fatalf("FinalScoringAction failed: %v", err)
+	}
+
+	scores := g.GetFinalScores()
+	for _, s := range scores {
+		if s.PlayerID == p1ID {
+			if s.Breakdown.GreeneryVP != 1 {
+				t.Errorf("GreeneryVP: expected 1, got %d", s.Breakdown.GreeneryVP)
+			}
+			// City at (1,-1,0) adjacent to greenery at (0,0,0) = 1 city VP
+			if s.Breakdown.CityVP != 1 {
+				t.Errorf("CityVP: expected 1, got %d", s.Breakdown.CityVP)
+			}
+			return
+		}
+	}
+	t.Fatal("Player 1 score not found")
+}

--- a/backend/test/game/cards/vp_calculator_test.go
+++ b/backend/test/game/cards/vp_calculator_test.go
@@ -1,0 +1,289 @@
+package cards_test
+
+import (
+	"context"
+	"testing"
+
+	"terraforming-mars-backend/internal/game/board"
+	gamecards "terraforming-mars-backend/internal/game/cards"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/test/testutil"
+)
+
+// TestFixedVPCard verifies that a card with a fixed VP condition
+// (e.g. Colonizer Training Camp, 2 VP) is correctly counted.
+func TestFixedVPCard(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	// Colonizer Training Camp (001): vpConditions: [{amount:2, condition:"fixed"}]
+	cardID := testutil.CardID("Colonizer Training Camp")
+	p.PlayedCards().AddCard(cardID, "Colonizer Training Camp", "automated", []string{"building", "jovian"})
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil, // no milestones
+		nil, // no awards
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CardVP != 2 {
+		t.Fatalf("expected CardVP=2 for Colonizer Training Camp, got %d", breakdown.CardVP)
+	}
+	if len(breakdown.CardVPDetails) != 1 {
+		t.Fatalf("expected 1 card VP detail, got %d", len(breakdown.CardVPDetails))
+	}
+	if breakdown.CardVPDetails[0].CardID != cardID {
+		t.Errorf("expected card ID %s, got %s", cardID, breakdown.CardVPDetails[0].CardID)
+	}
+	if breakdown.CardVPDetails[0].TotalVP != 2 {
+		t.Errorf("expected card detail TotalVP=2, got %d", breakdown.CardVPDetails[0].TotalVP)
+	}
+}
+
+// TestPerStorageVPCard verifies per-resource-on-self-card VP calculation.
+// Predators (024): 1 VP per animal on this card.
+func TestPerStorageVPCard(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	cardID := testutil.CardID("Predators")
+	p.PlayedCards().AddCard(cardID, "Predators", "active", []string{"animal"})
+
+	// Add 5 animals to the card
+	p.Resources().AddToStorage(cardID, 5)
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CardVP != 5 {
+		t.Fatalf("expected CardVP=5 for Predators with 5 animals, got %d", breakdown.CardVP)
+	}
+}
+
+// TestPerOceanTileVPCard verifies per-ocean-tile VP calculation.
+// Capital (008): 1 VP per ocean tile (placed on board).
+func TestPerOceanTileVPCard(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+	ctx := context.Background()
+
+	cardID := testutil.CardID("Capital")
+	p.PlayedCards().AddCard(cardID, "Capital", "automated", []string{"building", "city"})
+
+	// Place 3 ocean tiles on the board
+	oceanPositions := []shared.HexPosition{
+		{Q: -4, R: 0, S: 4},
+		{Q: -3, R: -1, S: 4},
+		{Q: -1, R: -2, S: 3},
+	}
+	for _, pos := range oceanPositions {
+		err := g.Board().UpdateTileOccupancy(ctx, pos, board.TileOccupant{
+			Type: shared.ResourceOceanTile,
+		}, "neutral")
+		if err != nil {
+			t.Fatalf("failed to place ocean tile: %v", err)
+		}
+	}
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CardVP != 3 {
+		t.Fatalf("expected CardVP=3 for Capital with 3 ocean tiles, got %d", breakdown.CardVP)
+	}
+}
+
+// TestGreeneryVP verifies 1 VP per owned greenery tile.
+func TestGreeneryVP(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+	ctx := context.Background()
+
+	// Place 2 greenery tiles owned by the player
+	greeneryPositions := []shared.HexPosition{
+		{Q: 0, R: 0, S: 0},
+		{Q: 1, R: 0, S: -1},
+	}
+	for _, pos := range greeneryPositions {
+		err := g.Board().UpdateTileOccupancy(ctx, pos, board.TileOccupant{
+			Type: shared.ResourceGreeneryTile,
+		}, p.ID())
+		if err != nil {
+			t.Fatalf("failed to place greenery: %v", err)
+		}
+	}
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.GreeneryVP != 2 {
+		t.Fatalf("expected GreeneryVP=2, got %d", breakdown.GreeneryVP)
+	}
+}
+
+// TestCityVP verifies VP from adjacent greenery tiles to owned cities.
+func TestCityVP(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+	ctx := context.Background()
+
+	// Place a city at (0,0,0)
+	err := g.Board().UpdateTileOccupancy(ctx, shared.HexPosition{Q: 0, R: 0, S: 0}, board.TileOccupant{
+		Type: shared.ResourceCityTile,
+	}, p.ID())
+	if err != nil {
+		t.Fatalf("failed to place city: %v", err)
+	}
+
+	// Place 2 greenery tiles adjacent to the city (neighbors of 0,0,0)
+	greeneryPositions := []shared.HexPosition{
+		{Q: 1, R: -1, S: 0}, // neighbor of (0,0,0)
+		{Q: 0, R: -1, S: 1}, // neighbor of (0,0,0)
+	}
+	for _, pos := range greeneryPositions {
+		err := g.Board().UpdateTileOccupancy(ctx, pos, board.TileOccupant{
+			Type: shared.ResourceGreeneryTile,
+		}, playerID)
+		if err != nil {
+			t.Fatalf("failed to place greenery: %v", err)
+		}
+	}
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CityVP != 2 {
+		t.Fatalf("expected CityVP=2, got %d", breakdown.CityVP)
+	}
+}
+
+// TestMultipleVPCards verifies total VP across multiple VP-granting cards.
+func TestMultipleVPCards(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	// Play Colonizer Training Camp (001): 2 VP fixed
+	p.PlayedCards().AddCard(testutil.CardID("Colonizer Training Camp"), "Colonizer Training Camp", "automated", []string{"building", "jovian"})
+
+	// Play Predators (024): 1 VP per animal on this card → add 3 animals = 3 VP
+	predatorsID := testutil.CardID("Predators")
+	p.PlayedCards().AddCard(predatorsID, "Predators", "active", []string{"animal"})
+	for i := 0; i < 3; i++ {
+		p.Resources().AddToStorage(predatorsID, 1)
+	}
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CardVP != 5 {
+		t.Fatalf("expected CardVP=5 (2+3), got %d", breakdown.CardVP)
+	}
+}
+
+// TestTotalVPSumsAllCategories verifies that TotalVP is the sum of all components.
+func TestTotalVPSumsAllCategories(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+	ctx := context.Background()
+
+	// Card VP: Colonizer Training Camp = 2 VP
+	p.PlayedCards().AddCard(testutil.CardID("Colonizer Training Camp"), "Colonizer Training Camp", "automated", []string{"building", "jovian"})
+
+	// Greenery VP: 1 greenery = 1 VP
+	err := g.Board().UpdateTileOccupancy(ctx, shared.HexPosition{Q: 0, R: 0, S: 0}, board.TileOccupant{
+		Type: shared.ResourceGreeneryTile,
+	}, p.ID())
+	if err != nil {
+		t.Fatalf("failed to place greenery: %v", err)
+	}
+
+	// Milestone VP: claim 1 milestone = 5 VP
+	milestones := []gamecards.ClaimedMilestoneInfo{
+		{Type: "terraformer", PlayerID: playerID},
+	}
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		milestones,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	expectedTotal := breakdown.TerraformRating + breakdown.CardVP + breakdown.MilestoneVP +
+		breakdown.AwardVP + breakdown.GreeneryVP + breakdown.CityVP
+
+	if breakdown.TotalVP != expectedTotal {
+		t.Fatalf("TotalVP %d != sum of parts %d (TR=%d Card=%d Milestone=%d Award=%d Greenery=%d City=%d)",
+			breakdown.TotalVP, expectedTotal,
+			breakdown.TerraformRating, breakdown.CardVP, breakdown.MilestoneVP,
+			breakdown.AwardVP, breakdown.GreeneryVP, breakdown.CityVP)
+	}
+
+	if breakdown.CardVP != 2 {
+		t.Errorf("expected CardVP=2, got %d", breakdown.CardVP)
+	}
+	if breakdown.GreeneryVP != 1 {
+		t.Errorf("expected GreeneryVP=1, got %d", breakdown.GreeneryVP)
+	}
+	if breakdown.MilestoneVP != 5 {
+		t.Errorf("expected MilestoneVP=5, got %d", breakdown.MilestoneVP)
+	}
+}
+
+// TestNoVPCards verifies that cards without VP conditions don't contribute.
+func TestNoVPCards(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	// Deep Well Heating (003) has no vpConditions
+	cardID := testutil.CardID("Deep Well Heating")
+	p.PlayedCards().AddCard(cardID, "Deep Well Heating", "automated", []string{"building", "power"})
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+	)
+
+	if breakdown.CardVP != 0 {
+		t.Fatalf("expected CardVP=0 for non-VP card, got %d", breakdown.CardVP)
+	}
+}

--- a/frontend/src/types/generated/api-types.ts
+++ b/frontend/src/types/generated/api-types.ts
@@ -1009,6 +1009,7 @@ export interface OtherPlayerDto {
   resourceStorage: { [key: string]: number /* int */ };
   paymentSubstitutes: PaymentSubstituteDto[];
   storagePaymentSubstitutes: StoragePaymentSubstituteDto[];
+  vpGranters: VPGranterDto[];
 }
 /**
  * GameDto represents a game for client consumption (clean architecture)


### PR DESCRIPTION
## Summary
- Add 8 unit tests for `CalculatePlayerVP` covering fixed VP, per-storage VP, per-ocean-tile VP, greenery VP, city VP, multiple cards, total VP sum, and no-VP cards
- Add 2 integration tests for `FinalScoringAction` verifying card VP and tile VP in the full scoring pipeline
- Expose `VPGranters` on `OtherPlayerDto` for opponent VP visibility (leftover from previous work, not included in PR #356)

## Test plan
- [x] All 10 new tests pass
- [x] All existing tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] TypeScript types regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)