### PR TITLE
Fix claude CLI missing from backend Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,14 +17,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 FROM alpine:latest
 WORKDIR /app
 
-RUN apk --no-cache add ca-certificates tzdata bash unzip curl libstdc++ libgcc && \
+RUN apk --no-cache add ca-certificates tzdata bash curl libstdc++ libgcc && \
     addgroup -g 1000 appuser && \
     adduser -D -u 1000 -G appuser appuser
 
-RUN curl -fsSL https://bun.sh/install | bash && \
-    ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
-    ln -s /root/.bun/bin/bunx /usr/local/bin/bunx && \
-    bun install -g @anthropic-ai/claude-code
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    chmod 755 /root && \
+    ln -s /root/.local/bin/claude /usr/local/bin/claude
 
 COPY --from=builder /build/server .
 COPY --from=builder /build/assets ./assets


### PR DESCRIPTION
## Summary

The bug report service couldn't find `claude` in production because:

1. It was installed via `bun install -g`, which puts binaries in `/root/.bun/bin/`
2. The container runs as `appuser`, who can't access `/root/`
3. No symlink was created for `claude` (unlike `bun` and `bunx`)

Switched to the official standalone installer (`claude.ai/install.sh`), which downloads a native binary and doesn't need bun or node at all. Also dropped `unzip` from apk since that was only needed for bun.

- Removed bun installation and all its symlinks
- Install via `curl -fsSL https://claude.ai/install.sh | bash`
- Symlink `/root/.local/bin/claude` to `/usr/local/bin/claude`
- `chmod 755 /root` so `appuser` can traverse the symlink chain

Verified locally: `docker run --rm tm-backend-test claude --version` → `2.1.72` running as `appuser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)