### PR TITLE
Redesign project funding for more strategic variety

### DIFF
--- a/backend/assets/terraforming_mars_project_funding.json
+++ b/backend/assets/terraforming_mars_project_funding.json
@@ -4,25 +4,22 @@
     "name": "Orbital Station",
     "description": "A massive orbital station providing research and logistics support.",
     "seats": [
-      { "cost": 5 },
-      { "cost": 7 },
-      { "cost": 9 },
-      { "cost": 11 },
-      { "cost": 13 },
+      { "cost": 6, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 8, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 12 },
       { "cost": 15 },
-      { "cost": 17 },
-      { "cost": 19 },
+      { "cost": 18 },
       { "cost": 21 },
-      { "cost": 24 }
+      { "cost": 25 }
     ],
     "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "credit", "amount": 6 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 12 }, { "type": "steel", "amount": 2 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "credit", "amount": 20 }, { "type": "steel", "amount": 4 }] }
+      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 5 }, { "type": "titanium", "amount": 2 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "credit", "amount": 12 }, { "type": "titanium", "amount": 4 }, { "type": "tr", "amount": 1 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 2 steel",
-      "rewards": [{ "type": "steel", "amount": 2 }]
+      "description": "All players gain 1 titanium and 1 TR",
+      "rewards": [{ "type": "titanium", "amount": 1 }, { "type": "tr", "amount": 1 }]
     },
     "style": { "color": "#4A90D9", "icon": "orbital-station" }
   },
@@ -31,25 +28,20 @@
     "name": "Deep Mine Network",
     "description": "An interconnected network of deep mining operations.",
     "seats": [
-      { "cost": 4, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 6, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
       { "cost": 8, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 10 },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 23 }
+      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 14, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 17, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 21, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] }
     ],
     "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "steel", "amount": 4 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "steel", "amount": 8 }, { "type": "titanium", "amount": 2 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "steel", "amount": 12 }, { "type": "titanium", "amount": 4 }] }
+      { "seatsOwned": 1, "rewards": [{ "type": "steel", "amount": 3 }, { "type": "titanium", "amount": 1 }] },
+      { "seatsOwned": 3, "rewards": [{ "type": "steel", "amount": 8 }, { "type": "titanium", "amount": 3 }, { "type": "vp", "amount": 2 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 3 steel and 1 titanium",
-      "rewards": [{ "type": "steel", "amount": 3 }, { "type": "titanium", "amount": 1 }]
+      "description": "All players gain 2 steel",
+      "rewards": [{ "type": "steel", "amount": 2 }]
     },
     "style": { "color": "#8B4513", "icon": "deep-mine" }
   },
@@ -57,141 +49,6 @@
     "id": "pf_terraforming_hub",
     "name": "Terraforming Hub",
     "description": "A central hub coordinating planetary engineering efforts.",
-    "seats": [
-      { "cost": 8 },
-      { "cost": 10 },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 22 },
-      { "cost": 25 },
-      { "cost": 28 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "tr", "amount": 1 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "tr", "amount": 2 }, { "type": "plant", "amount": 3 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "tr", "amount": 3 }, { "type": "plant", "amount": 6 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 1 TR",
-      "rewards": [{ "type": "tr", "amount": 1 }]
-    },
-    "style": { "color": "#2E8B57", "icon": "terraforming-hub" }
-  },
-  {
-    "id": "pf_solar_array",
-    "name": "Solar Array",
-    "description": "A vast solar collection system powering the colony.",
-    "seats": [
-      { "cost": 4 },
-      { "cost": 6 },
-      { "cost": 8 },
-      { "cost": 10 },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 22 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "energy", "amount": 4 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "energy", "amount": 8 }, { "type": "heat", "amount": 4 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "energy", "amount": 12 }, { "type": "heat", "amount": 8 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 3 energy and 2 heat",
-      "rewards": [{ "type": "energy", "amount": 3 }, { "type": "heat", "amount": 2 }]
-    },
-    "style": { "color": "#FFD700", "icon": "solar-array" }
-  },
-  {
-    "id": "pf_biodome",
-    "name": "Biodome Complex",
-    "description": "A network of biodomes cultivating diverse ecosystems.",
-    "seats": [
-      { "cost": 6 },
-      { "cost": 8 },
-      { "cost": 10 },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 22 },
-      { "cost": 25 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "plant", "amount": 5 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "plant", "amount": 10 }, { "type": "heat", "amount": 3 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "plant", "amount": 16 }, { "type": "heat", "amount": 6 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 4 plants",
-      "rewards": [{ "type": "plant", "amount": 4 }]
-    },
-    "style": { "color": "#228B22", "icon": "biodome" }
-  },
-  {
-    "id": "pf_space_elevator",
-    "name": "Space Elevator",
-    "description": "A tethered structure connecting the surface to orbit.",
-    "seats": [
-      { "cost": 6, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 8, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 23 },
-      { "cost": 26 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "titanium", "amount": 3 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "titanium", "amount": 6 }, { "type": "credit", "amount": 6 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "titanium", "amount": 10 }, { "type": "credit", "amount": 12 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 2 titanium",
-      "rewards": [{ "type": "titanium", "amount": 2 }]
-    },
-    "style": { "color": "#708090", "icon": "space-elevator" }
-  },
-  {
-    "id": "pf_research_outpost",
-    "name": "Research Outpost",
-    "description": "An advanced research facility pushing scientific boundaries.",
-    "seats": [
-      { "cost": 7 },
-      { "cost": 9 },
-      { "cost": 11 },
-      { "cost": 13 },
-      { "cost": 15 },
-      { "cost": 17 },
-      { "cost": 19 },
-      { "cost": 21 },
-      { "cost": 24 },
-      { "cost": 27 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "vp", "amount": 2 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "vp", "amount": 4 }, { "type": "credit", "amount": 8 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "vp", "amount": 7 }, { "type": "credit", "amount": 14 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 1 VP",
-      "rewards": [{ "type": "vp", "amount": 1 }]
-    },
-    "style": { "color": "#9370DB", "icon": "research-outpost" }
-  },
-  {
-    "id": "pf_thermal_plant",
-    "name": "Thermal Plant",
-    "description": "A geothermal energy plant tapping into the planet's core.",
     "seats": [
       { "cost": 5 },
       { "cost": 7 },
@@ -202,71 +59,193 @@
       { "cost": 17 },
       { "cost": 19 },
       { "cost": 21 },
+      { "cost": 23 },
+      { "cost": 26 },
+      { "cost": 30 }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 2, "rewards": [{ "type": "tr", "amount": 1 }, { "type": "plant", "amount": 3 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "tr", "amount": 2 }, { "type": "plant", "amount": 6 }, { "type": "vp", "amount": 2 }] },
+      { "seatsOwned": 6, "rewards": [{ "type": "tr", "amount": 4 }, { "type": "plant", "amount": 10 }, { "type": "vp", "amount": 5 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 1 TR and 2 plants",
+      "rewards": [{ "type": "tr", "amount": 1 }, { "type": "plant", "amount": 2 }]
+    },
+    "style": { "color": "#2E8B57", "icon": "terraforming-hub" }
+  },
+  {
+    "id": "pf_solar_forge",
+    "name": "Solar Forge",
+    "description": "A massive solar installation converting light to industrial heat.",
+    "seats": [
+      { "cost": 4 },
+      { "cost": 6 },
+      { "cost": 9 },
+      { "cost": 12 },
+      { "cost": 15 },
+      { "cost": 19 },
       { "cost": 24 }
     ],
     "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "heat", "amount": 6 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "heat", "amount": 12 }, { "type": "energy", "amount": 4 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "heat", "amount": 18 }, { "type": "energy", "amount": 8 }] }
+      { "seatsOwned": 1, "rewards": [{ "type": "heat", "amount": 4 }, { "type": "energy", "amount": 2 }] },
+      { "seatsOwned": 3, "rewards": [{ "type": "heat", "amount": 10 }, { "type": "energy", "amount": 5 }, { "type": "tr", "amount": 1 }] }
     ],
     "completionEffect": {
       "description": "All players gain 4 heat",
       "rewards": [{ "type": "heat", "amount": 4 }]
     },
-    "style": { "color": "#DC143C", "icon": "thermal-plant" }
+    "style": { "color": "#FFD700", "icon": "solar-forge" }
   },
   {
-    "id": "pf_water_treatment",
-    "name": "Water Treatment Facility",
-    "description": "A facility purifying and distributing water across the colony.",
+    "id": "pf_genesis_preserve",
+    "name": "Genesis Preserve",
+    "description": "A massive bio-engineering preserve cultivating alien ecosystems.",
     "seats": [
-      { "cost": 6 },
-      { "cost": 8 },
-      { "cost": 10 },
-      { "cost": 12 },
-      { "cost": 14 },
-      { "cost": 16 },
-      { "cost": 18 },
-      { "cost": 20 },
-      { "cost": 23 },
-      { "cost": 26 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "credit", "amount": 8 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 14 }, { "type": "plant", "amount": 4 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "credit", "amount": 22 }, { "type": "plant", "amount": 8 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 3 credits and 2 plants",
-      "rewards": [{ "type": "credit", "amount": 3 }, { "type": "plant", "amount": 2 }]
-    },
-    "style": { "color": "#4169E1", "icon": "water-treatment" }
-  },
-  {
-    "id": "pf_mag_lev_network",
-    "name": "Mag-Lev Network",
-    "description": "A magnetic levitation transport system connecting settlements.",
-    "seats": [
-      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 7 },
       { "cost": 9 },
       { "cost": 11 },
       { "cost": 13 },
       { "cost": 15 },
       { "cost": 17 },
-      { "cost": 19 },
-      { "cost": 21 },
+      { "cost": 20 },
       { "cost": 24 }
     ],
     "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "credit", "amount": 5 }, { "type": "steel", "amount": 2 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 10 }, { "type": "steel", "amount": 5 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "credit", "amount": 16 }, { "type": "steel", "amount": 8 }, { "type": "vp", "amount": 2 }] }
+      { "seatsOwned": 2, "rewards": [{ "type": "plant", "amount": 6 }, { "type": "heat", "amount": 2 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "plant", "amount": 12 }, { "type": "heat", "amount": 4 }, { "type": "vp", "amount": 3 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 2 credits and 1 steel",
-      "rewards": [{ "type": "credit", "amount": 2 }, { "type": "steel", "amount": 1 }]
+      "description": "All players gain 3 plants and 1 VP",
+      "rewards": [{ "type": "plant", "amount": 3 }, { "type": "vp", "amount": 1 }]
     },
-    "style": { "color": "#B8860B", "icon": "mag-lev" }
+    "style": { "color": "#228B22", "icon": "genesis-preserve" }
+  },
+  {
+    "id": "pf_space_elevator",
+    "name": "Space Elevator",
+    "description": "A tethered structure connecting the surface to orbit.",
+    "seats": [
+      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 13, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 16 },
+      { "cost": 19 },
+      { "cost": 22 },
+      { "cost": 25 },
+      { "cost": 29 }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 2, "rewards": [{ "type": "titanium", "amount": 4 }, { "type": "credit", "amount": 4 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "titanium", "amount": 8 }, { "type": "credit", "amount": 10 }, { "type": "vp", "amount": 1 }] },
+      { "seatsOwned": 6, "rewards": [{ "type": "titanium", "amount": 14 }, { "type": "credit", "amount": 18 }, { "type": "vp", "amount": 3 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 2 titanium",
+      "rewards": [{ "type": "titanium", "amount": 2 }]
+    },
+    "style": { "color": "#708090", "icon": "space-elevator" }
+  },
+  {
+    "id": "pf_phobos_research_lab",
+    "name": "Phobos Research Lab",
+    "description": "A high-risk research station on Phobos pushing scientific boundaries.",
+    "seats": [
+      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 14, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 18, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 23, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
+      { "cost": 28, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 1, "rewards": [{ "type": "vp", "amount": 2 }] },
+      { "seatsOwned": 2, "rewards": [{ "type": "vp", "amount": 4 }, { "type": "titanium", "amount": 3 }] },
+      { "seatsOwned": 3, "rewards": [{ "type": "vp", "amount": 7 }, { "type": "titanium", "amount": 6 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 2 VP",
+      "rewards": [{ "type": "vp", "amount": 2 }]
+    },
+    "style": { "color": "#9370DB", "icon": "phobos-research-lab" }
+  },
+  {
+    "id": "pf_thermal_plant",
+    "name": "Thermal Plant",
+    "description": "A geothermal energy plant tapping into the planet's core.",
+    "seats": [
+      { "cost": 4, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 6, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 8, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 13 },
+      { "cost": 16 },
+      { "cost": 19 },
+      { "cost": 23 }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 2, "rewards": [{ "type": "heat", "amount": 8 }, { "type": "energy", "amount": 3 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "heat", "amount": 14 }, { "type": "energy", "amount": 6 }, { "type": "tr", "amount": 1 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 3 heat and 1 energy",
+      "rewards": [{ "type": "heat", "amount": 3 }, { "type": "energy", "amount": 1 }]
+    },
+    "style": { "color": "#DC143C", "icon": "thermal-plant" }
+  },
+  {
+    "id": "pf_aquifer_network",
+    "name": "Aquifer Network",
+    "description": "Underground water infrastructure distributing water across the colony.",
+    "seats": [
+      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 11 },
+      { "cost": 14 },
+      { "cost": 17 },
+      { "cost": 20 },
+      { "cost": 23 },
+      { "cost": 27 }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 6 }, { "type": "plant", "amount": 4 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "credit", "amount": 12 }, { "type": "plant", "amount": 8 }, { "type": "tr", "amount": 1 }] },
+      { "seatsOwned": 6, "rewards": [{ "type": "credit", "amount": 20 }, { "type": "plant", "amount": 14 }, { "type": "vp", "amount": 2 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 2 credits and 2 plants",
+      "rewards": [{ "type": "credit", "amount": 2 }, { "type": "plant", "amount": 2 }]
+    },
+    "style": { "color": "#4169E1", "icon": "aquifer-network" }
+  },
+  {
+    "id": "pf_hellas_rail",
+    "name": "Hellas Rail",
+    "description": "A transcontinental rail system through Hellas basin connecting settlements.",
+    "seats": [
+      { "cost": 3, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 13, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
+      { "cost": 15 },
+      { "cost": 17 },
+      { "cost": 20 },
+      { "cost": 23 },
+      { "cost": 27 }
+    ],
+    "rewardTiers": [
+      { "seatsOwned": 2, "rewards": [{ "type": "steel", "amount": 4 }, { "type": "credit", "amount": 4 }] },
+      { "seatsOwned": 5, "rewards": [{ "type": "steel", "amount": 10 }, { "type": "credit", "amount": 10 }, { "type": "vp", "amount": 2 }] },
+      { "seatsOwned": 8, "rewards": [{ "type": "steel", "amount": 16 }, { "type": "credit", "amount": 18 }, { "type": "vp", "amount": 5 }] }
+    ],
+    "completionEffect": {
+      "description": "All players gain 2 steel and 1 credit",
+      "rewards": [{ "type": "steel", "amount": 2 }, { "type": "credit", "amount": 1 }]
+    },
+    "style": { "color": "#B8860B", "icon": "hellas-rail" }
   }
 ]


### PR DESCRIPTION
## Summary
- Varied seat counts across projects (5–12, was all 10) for different pacing
- Reworked 5 projects with new themes: Solar Forge, Genesis Preserve, Phobos Research Lab, Aquifer Network, Hellas Rail
- Expanded payment substitutes to 7/10 projects (was 3/10) with thematic resource ties
- Added VP rewards to 7/10 projects and TR rewards to 5/10 projects
- Diversified tier thresholds (2/4, 1/3, 2/4/6, 2/5/8, etc.) instead of uniform 1/2/3

## Test plan
- [x] `make test` passes (all 23 suites)
- [ ] Run `make run` and verify project funding popover renders correctly
- [ ] Check seat counts, costs, payment substitutes, and reward tiers display
- [ ] Buy a seat using steel/titanium substitutes on eligible projects
- [ ] Complete a small project (Deep Mine, 6 seats) and verify tier + completion rewards

🤖 Generated with [Claude Code](https://claude.com/claude-code)