### PR TITLE
feat: 3 fixed project funding projects with dramatic completions

### DIFF
--- a/backend/assets/terraforming_mars_project_funding.json
+++ b/backend/assets/terraforming_mars_project_funding.json
@@ -9,41 +9,42 @@
       { "cost": 10, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
       { "cost": 12 },
       { "cost": 15 },
-      { "cost": 18 },
-      { "cost": 21 },
-      { "cost": 25 }
+      { "cost": 18 }
     ],
     "rewardTiers": [
       { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 5 }, { "type": "titanium", "amount": 2 }] },
       { "seatsOwned": 4, "rewards": [{ "type": "credit", "amount": 12 }, { "type": "titanium", "amount": 4 }, { "type": "tr", "amount": 1 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 1 titanium and 1 TR",
-      "rewards": [{ "type": "titanium", "amount": 1 }, { "type": "tr", "amount": 1 }]
+      "description": "Each player is dealt 20 cards directly to hand",
+      "rewards": [],
+      "globalEffects": [{ "type": "card-draw", "amount": 20 }]
     },
+    "firstFunderBonus": [{ "type": "titanium", "amount": 2 }],
     "style": { "color": "#4A90D9", "icon": "orbital-station" }
   },
   {
-    "id": "pf_deep_mine",
-    "name": "Deep Mine Network",
-    "description": "An interconnected network of deep mining operations.",
+    "id": "pf_solar_forge",
+    "name": "Solar Forge",
+    "description": "A massive solar installation converting light to industrial heat.",
     "seats": [
-      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 8, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 14, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 17, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 21, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] }
+      { "cost": 5 },
+      { "cost": 8 },
+      { "cost": 12 },
+      { "cost": 16 },
+      { "cost": 21 }
     ],
     "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "steel", "amount": 3 }, { "type": "titanium", "amount": 1 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "steel", "amount": 8 }, { "type": "titanium", "amount": 3 }, { "type": "vp", "amount": 2 }] }
+      { "seatsOwned": 1, "rewards": [{ "type": "heat", "amount": 4 }, { "type": "energy", "amount": 2 }] },
+      { "seatsOwned": 3, "rewards": [{ "type": "heat", "amount": 10 }, { "type": "energy", "amount": 5 }, { "type": "energy-production", "amount": 1 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 2 steel",
-      "rewards": [{ "type": "steel", "amount": 2 }]
+      "description": "Each player chooses +10 production of any type",
+      "rewards": [],
+      "globalEffects": [{ "type": "production-choice", "amount": 10 }]
     },
-    "style": { "color": "#8B4513", "icon": "deep-mine" }
+    "firstFunderBonus": [{ "type": "heat", "amount": 4 }],
+    "style": { "color": "#FFD700", "icon": "solar-forge" }
   },
   {
     "id": "pf_terraforming_hub",
@@ -55,197 +56,20 @@
       { "cost": 9 },
       { "cost": 11 },
       { "cost": 13 },
-      { "cost": 15 },
-      { "cost": 17 },
-      { "cost": 19 },
-      { "cost": 21 },
-      { "cost": 23 },
-      { "cost": 26 },
-      { "cost": 30 }
+      { "cost": 16 },
+      { "cost": 20 }
     ],
     "rewardTiers": [
       { "seatsOwned": 2, "rewards": [{ "type": "tr", "amount": 1 }, { "type": "plant", "amount": 3 }] },
-      { "seatsOwned": 4, "rewards": [{ "type": "tr", "amount": 2 }, { "type": "plant", "amount": 6 }, { "type": "vp", "amount": 2 }] },
+      { "seatsOwned": 4, "rewards": [{ "type": "tr", "amount": 2 }, { "type": "plant", "amount": 6 }, { "type": "plant-production", "amount": 1 }] },
       { "seatsOwned": 6, "rewards": [{ "type": "tr", "amount": 4 }, { "type": "plant", "amount": 10 }, { "type": "vp", "amount": 5 }] }
     ],
     "completionEffect": {
-      "description": "All players gain 1 TR and 2 plants",
-      "rewards": [{ "type": "tr", "amount": 1 }, { "type": "plant", "amount": 2 }]
+      "description": "+5 TR to all players + raise oxygen 2 steps",
+      "rewards": [{ "type": "tr", "amount": 5 }],
+      "globalEffects": [{ "type": "oxygen", "amount": 2 }]
     },
+    "firstFunderBonus": [{ "type": "tr", "amount": 2 }],
     "style": { "color": "#2E8B57", "icon": "terraforming-hub" }
-  },
-  {
-    "id": "pf_solar_forge",
-    "name": "Solar Forge",
-    "description": "A massive solar installation converting light to industrial heat.",
-    "seats": [
-      { "cost": 4 },
-      { "cost": 6 },
-      { "cost": 9 },
-      { "cost": 12 },
-      { "cost": 15 },
-      { "cost": 19 },
-      { "cost": 24 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "heat", "amount": 4 }, { "type": "energy", "amount": 2 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "heat", "amount": 10 }, { "type": "energy", "amount": 5 }, { "type": "tr", "amount": 1 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 4 heat",
-      "rewards": [{ "type": "heat", "amount": 4 }]
-    },
-    "style": { "color": "#FFD700", "icon": "solar-forge" }
-  },
-  {
-    "id": "pf_genesis_preserve",
-    "name": "Genesis Preserve",
-    "description": "A massive bio-engineering preserve cultivating alien ecosystems.",
-    "seats": [
-      { "cost": 7 },
-      { "cost": 9 },
-      { "cost": 11 },
-      { "cost": 13 },
-      { "cost": 15 },
-      { "cost": 17 },
-      { "cost": 20 },
-      { "cost": 24 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 2, "rewards": [{ "type": "plant", "amount": 6 }, { "type": "heat", "amount": 2 }] },
-      { "seatsOwned": 4, "rewards": [{ "type": "plant", "amount": 12 }, { "type": "heat", "amount": 4 }, { "type": "vp", "amount": 3 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 3 plants and 1 VP",
-      "rewards": [{ "type": "plant", "amount": 3 }, { "type": "vp", "amount": 1 }]
-    },
-    "style": { "color": "#228B22", "icon": "genesis-preserve" }
-  },
-  {
-    "id": "pf_space_elevator",
-    "name": "Space Elevator",
-    "description": "A tethered structure connecting the surface to orbit.",
-    "seats": [
-      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 13, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 16 },
-      { "cost": 19 },
-      { "cost": 22 },
-      { "cost": 25 },
-      { "cost": 29 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 2, "rewards": [{ "type": "titanium", "amount": 4 }, { "type": "credit", "amount": 4 }] },
-      { "seatsOwned": 4, "rewards": [{ "type": "titanium", "amount": 8 }, { "type": "credit", "amount": 10 }, { "type": "vp", "amount": 1 }] },
-      { "seatsOwned": 6, "rewards": [{ "type": "titanium", "amount": 14 }, { "type": "credit", "amount": 18 }, { "type": "vp", "amount": 3 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 2 titanium",
-      "rewards": [{ "type": "titanium", "amount": 2 }]
-    },
-    "style": { "color": "#708090", "icon": "space-elevator" }
-  },
-  {
-    "id": "pf_phobos_research_lab",
-    "name": "Phobos Research Lab",
-    "description": "A high-risk research station on Phobos pushing scientific boundaries.",
-    "seats": [
-      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 14, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 18, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 23, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] },
-      { "cost": 28, "paymentSubstitutes": [{ "resourceType": "titanium", "conversionRate": 3 }] }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 1, "rewards": [{ "type": "vp", "amount": 2 }] },
-      { "seatsOwned": 2, "rewards": [{ "type": "vp", "amount": 4 }, { "type": "titanium", "amount": 3 }] },
-      { "seatsOwned": 3, "rewards": [{ "type": "vp", "amount": 7 }, { "type": "titanium", "amount": 6 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 2 VP",
-      "rewards": [{ "type": "vp", "amount": 2 }]
-    },
-    "style": { "color": "#9370DB", "icon": "phobos-research-lab" }
-  },
-  {
-    "id": "pf_thermal_plant",
-    "name": "Thermal Plant",
-    "description": "A geothermal energy plant tapping into the planet's core.",
-    "seats": [
-      { "cost": 4, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 6, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 8, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 10, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 13 },
-      { "cost": 16 },
-      { "cost": 19 },
-      { "cost": 23 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 2, "rewards": [{ "type": "heat", "amount": 8 }, { "type": "energy", "amount": 3 }] },
-      { "seatsOwned": 4, "rewards": [{ "type": "heat", "amount": 14 }, { "type": "energy", "amount": 6 }, { "type": "tr", "amount": 1 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 3 heat and 1 energy",
-      "rewards": [{ "type": "heat", "amount": 3 }, { "type": "energy", "amount": 1 }]
-    },
-    "style": { "color": "#DC143C", "icon": "thermal-plant" }
-  },
-  {
-    "id": "pf_aquifer_network",
-    "name": "Aquifer Network",
-    "description": "Underground water infrastructure distributing water across the colony.",
-    "seats": [
-      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 11 },
-      { "cost": 14 },
-      { "cost": 17 },
-      { "cost": 20 },
-      { "cost": 23 },
-      { "cost": 27 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 2, "rewards": [{ "type": "credit", "amount": 6 }, { "type": "plant", "amount": 4 }] },
-      { "seatsOwned": 4, "rewards": [{ "type": "credit", "amount": 12 }, { "type": "plant", "amount": 8 }, { "type": "tr", "amount": 1 }] },
-      { "seatsOwned": 6, "rewards": [{ "type": "credit", "amount": 20 }, { "type": "plant", "amount": 14 }, { "type": "vp", "amount": 2 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 2 credits and 2 plants",
-      "rewards": [{ "type": "credit", "amount": 2 }, { "type": "plant", "amount": 2 }]
-    },
-    "style": { "color": "#4169E1", "icon": "aquifer-network" }
-  },
-  {
-    "id": "pf_hellas_rail",
-    "name": "Hellas Rail",
-    "description": "A transcontinental rail system through Hellas basin connecting settlements.",
-    "seats": [
-      { "cost": 3, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 5, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 7, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 9, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 11, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 13, "paymentSubstitutes": [{ "resourceType": "steel", "conversionRate": 2 }] },
-      { "cost": 15 },
-      { "cost": 17 },
-      { "cost": 20 },
-      { "cost": 23 },
-      { "cost": 27 }
-    ],
-    "rewardTiers": [
-      { "seatsOwned": 2, "rewards": [{ "type": "steel", "amount": 4 }, { "type": "credit", "amount": 4 }] },
-      { "seatsOwned": 5, "rewards": [{ "type": "steel", "amount": 10 }, { "type": "credit", "amount": 10 }, { "type": "vp", "amount": 2 }] },
-      { "seatsOwned": 8, "rewards": [{ "type": "steel", "amount": 16 }, { "type": "credit", "amount": 18 }, { "type": "vp", "amount": 5 }] }
-    ],
-    "completionEffect": {
-      "description": "All players gain 2 steel and 1 credit",
-      "rewards": [{ "type": "steel", "amount": 2 }, { "type": "credit", "amount": 1 }]
-    },
-    "style": { "color": "#B8860B", "icon": "hellas-rail" }
   }
 ]

--- a/backend/internal/action/projectfunding/fund_seat.go
+++ b/backend/internal/action/projectfunding/fund_seat.go
@@ -172,6 +172,17 @@ func (a *FundSeatAction) Execute(ctx context.Context, gameID string, playerID st
 		CalculatedOutputs: calculatedOutputs,
 	})
 
+	// Apply first-funder bonus to the first seat buyer
+	if seatIndex == 0 && len(definition.FirstFunderBonus) > 0 {
+		bonusOutputs := applyRewards(player, definition.FirstFunderBonus)
+		g.AddTriggeredEffect(shared.TriggeredEffect{
+			CardName:          definition.Name + " (First Funder)",
+			PlayerID:          playerID,
+			SourceType:        shared.SourceTypeProjectFundingSeat,
+			CalculatedOutputs: bonusOutputs,
+		})
+	}
+
 	a.WriteStateLogFull(ctx, g, definition.Name, shared.SourceTypeProjectFundingSeat,
 		playerID, fmt.Sprintf("Funded %s project", definition.Name), nil, calculatedOutputs, nil)
 
@@ -231,7 +242,7 @@ func (a *FundSeatAction) completeProject(ctx context.Context, g *game.Game, stat
 		})
 	}
 
-	// Apply completion effect to ALL players
+	// Apply static completion rewards to ALL players
 	for _, p := range allPlayers {
 		completionOutputs := applyRewards(p, def.CompletionEffect.Rewards)
 
@@ -241,6 +252,12 @@ func (a *FundSeatAction) completeProject(ctx context.Context, g *game.Game, stat
 			SourceType:        shared.SourceTypeProjectFundingCompletion,
 			CalculatedOutputs: completionOutputs,
 		})
+	}
+
+	// Apply global completion effects
+	if len(def.CompletionEffect.GlobalEffects) > 0 {
+		completingPlayerID := state.SeatOwners[len(state.SeatOwners)-1]
+		a.applyGlobalEffects(ctx, g, def, allPlayers, completingPlayerID, log)
 	}
 
 	a.WriteStateLogFull(ctx, g, "Project Completed: "+def.Name, shared.SourceTypeProjectFundingCompletion,
@@ -257,9 +274,80 @@ func (a *FundSeatAction) completeProject(ctx context.Context, g *game.Game, stat
 		zap.Int("total_seats", len(state.SeatOwners)))
 }
 
+func (a *FundSeatAction) applyGlobalEffects(ctx context.Context, g *game.Game, def *pf.ProjectDefinition, allPlayers []*player.Player, completingPlayerID string, log *zap.Logger) {
+	for _, effect := range def.CompletionEffect.GlobalEffects {
+		switch effect.Type {
+		case "temperature":
+			if _, err := g.GlobalParameters().IncreaseTemperature(ctx, effect.Amount, completingPlayerID); err != nil {
+				log.Error("Failed to increase temperature for project completion", zap.Error(err))
+			}
+		case "oxygen":
+			if _, err := g.GlobalParameters().IncreaseOxygen(ctx, effect.Amount, completingPlayerID); err != nil {
+				log.Error("Failed to increase oxygen for project completion", zap.Error(err))
+			}
+		case "freeze-turn-order":
+			g.SetNextGenTurnOrderFrozen(true)
+			log.Debug("Turn order frozen by project completion", zap.String("project", def.Name))
+		case "production-choice":
+			amount := effect.Amount
+			if amount <= 0 {
+				amount = 1
+			}
+			choices := buildProductionChoices(amount)
+			for _, p := range allPlayers {
+				p.Selection().SetPendingBehaviorChoiceSelection(&shared.PendingBehaviorChoiceSelection{
+					Choices:      choices,
+					Source:       "project-funding-completion",
+					SourceCardID: def.ID,
+				})
+			}
+			log.Debug("Production choice set for all players", zap.String("project", def.Name))
+		case "card-draw":
+			n := effect.Amount
+			if n <= 0 {
+				n = 1
+			}
+			for _, p := range allPlayers {
+				cardIDs, err := g.Deck().DrawProjectCards(ctx, n)
+				if err != nil {
+					log.Error("Failed to draw cards for project completion", zap.Error(err))
+					break
+				}
+				for _, cardID := range cardIDs {
+					p.Hand().AddCard(cardID)
+				}
+				log.Debug("Cards drawn for player",
+					zap.String("player_id", p.ID()),
+					zap.Int("count", len(cardIDs)))
+			}
+		}
+	}
+}
+
+func buildProductionChoices(amount int) []shared.Choice {
+	productionTypes := []shared.ResourceType{
+		shared.ResourceCreditProduction,
+		shared.ResourceSteelProduction,
+		shared.ResourceTitaniumProduction,
+		shared.ResourcePlantProduction,
+		shared.ResourceEnergyProduction,
+		shared.ResourceHeatProduction,
+	}
+	choices := make([]shared.Choice, len(productionTypes))
+	for i, rt := range productionTypes {
+		choices[i] = shared.Choice{
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: rt, Amount: amount, Target: "self-player"},
+			},
+		}
+	}
+	return choices
+}
+
 func applyRewards(p *player.Player, rewards []pf.Output) []shared.CalculatedOutput {
 	var outputs []shared.CalculatedOutput
 	resourceAdds := map[shared.ResourceType]int{}
+	productionAdds := map[shared.ResourceType]int{}
 
 	for _, reward := range rewards {
 		outputs = append(outputs, shared.CalculatedOutput{
@@ -292,11 +380,26 @@ func applyRewards(p *player.Player, rewards []pf.Output) []shared.CalculatedOutp
 				},
 				ComputedValue: reward.Amount,
 			})
+		case "credit-production":
+			productionAdds[shared.ResourceCreditProduction] += reward.Amount
+		case "steel-production":
+			productionAdds[shared.ResourceSteelProduction] += reward.Amount
+		case "titanium-production":
+			productionAdds[shared.ResourceTitaniumProduction] += reward.Amount
+		case "plant-production":
+			productionAdds[shared.ResourcePlantProduction] += reward.Amount
+		case "energy-production":
+			productionAdds[shared.ResourceEnergyProduction] += reward.Amount
+		case "heat-production":
+			productionAdds[shared.ResourceHeatProduction] += reward.Amount
 		}
 	}
 
 	if len(resourceAdds) > 0 {
 		p.Resources().Add(resourceAdds)
+	}
+	if len(productionAdds) > 0 {
+		p.Resources().AddProduction(productionAdds)
 	}
 
 	return outputs

--- a/backend/internal/action/turn_management/start_game.go
+++ b/backend/internal/action/turn_management/start_game.go
@@ -105,7 +105,7 @@ func (a *StartGameAction) Execute(ctx context.Context, gameID string, playerID s
 
 	// 5c. BUSINESS LOGIC: Initialize project funding if enabled
 	if g.Settings().HasProjectFunding() {
-		a.initializeProjectFunding(g, playerIDs, rng, log)
+		a.initializeProjectFunding(g, log)
 	}
 
 	// 6. BUSINESS LOGIC: Ensure deck is initialized
@@ -223,7 +223,7 @@ func (a *StartGameAction) initializeColonies(g *game.Game, playerIDs []string, r
 		zap.Int("player_count", len(playerIDs)))
 }
 
-func (a *StartGameAction) initializeProjectFunding(g *game.Game, playerIDs []string, rng *rand.Rand, log *zap.Logger) {
+func (a *StartGameAction) initializeProjectFunding(g *game.Game, log *zap.Logger) {
 	if a.projectFundingRegistry == nil {
 		log.Warn("No project funding registry available")
 		return
@@ -235,24 +235,8 @@ func (a *StartGameAction) initializeProjectFunding(g *game.Game, playerIDs []str
 		return
 	}
 
-	// Select N+2 projects (min 4)
-	numToSelect := len(playerIDs) + 2
-	if numToSelect < 4 {
-		numToSelect = 4
-	}
-	if numToSelect > len(allProjects) {
-		numToSelect = len(allProjects)
-	}
-
-	// Shuffle and pick
-	rng.Shuffle(len(allProjects), func(i, j int) {
-		allProjects[i], allProjects[j] = allProjects[j], allProjects[i]
-	})
-	selected := allProjects[:numToSelect]
-
-	// Initialize project states
-	states := make([]*projectfunding.ProjectState, len(selected))
-	for i, def := range selected {
+	states := make([]*projectfunding.ProjectState, len(allProjects))
+	for i, def := range allProjects {
 		states[i] = &projectfunding.ProjectState{
 			DefinitionID: def.ID,
 			SeatOwners:   []string{},
@@ -261,9 +245,7 @@ func (a *StartGameAction) initializeProjectFunding(g *game.Game, playerIDs []str
 	}
 	g.SetProjectFundingStates(states)
 
-	log.Debug("Project funding initialized",
-		zap.Int("project_count", len(states)),
-		zap.Int("player_count", len(playerIDs)))
+	log.Debug("Project funding initialized", zap.Int("project_count", len(states)))
 }
 
 func (a *StartGameAction) distributeCorporations(ctx context.Context, g *game.Game, players []*playerPkg.Player) error {

--- a/backend/test/action/projectfunding/fund_seat_test.go
+++ b/backend/test/action/projectfunding/fund_seat_test.go
@@ -260,6 +260,7 @@ func TestFundSeat_Completion_AllPlayersGetCompletionEffect(t *testing.T) {
 	testGame, repo, pfRegistry, player1, player2 := setupProjectFundingGame(t)
 	ctx := context.Background()
 
+	// pf_orbital_station completion effect: card-draw (5 cards for each player)
 	def, _ := pfRegistry.GetByID("pf_orbital_station")
 	owners := make([]string, len(def.Seats)-1)
 	for i := range owners {
@@ -270,33 +271,17 @@ func TestFundSeat_Completion_AllPlayersGetCompletionEffect(t *testing.T) {
 	p1, _ := testGame.GetPlayer(player1)
 	p2, _ := testGame.GetPlayer(player2)
 	testutil.SetPlayerCredits(ctx, p1, 500)
-	testutil.SetPlayerCredits(ctx, p2, 100)
 
-	p2CreditsBefore := testutil.GetPlayerCredits(p2)
+	p2HandBefore := len(p2.Hand().Cards())
 	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
 	testutil.AssertNoError(t, err, "Buy last seat should succeed")
 
-	// Player2 should receive completion effect even though they have no seats
-	hasCompletionReward := false
-	for _, reward := range def.CompletionEffect.Rewards {
-		if reward.Type == "credit" && reward.Amount > 0 {
-			p2CreditsAfter := testutil.GetPlayerCredits(p2)
-			if p2CreditsAfter > p2CreditsBefore {
-				hasCompletionReward = true
-			}
-		}
-	}
-
-	// If completion reward is not credits, check other resources
-	if !hasCompletionReward && len(def.CompletionEffect.Rewards) > 0 {
-		// Completion effect was applied (we trust the code path)
-		hasCompletionReward = true
-	}
-
-	testutil.AssertTrue(t, hasCompletionReward, "Player2 should get completion effect even without seats")
+	// Player2 should receive the card-draw completion effect even though they have no seats
+	p2HandAfter := len(p2.Hand().Cards())
+	testutil.AssertTrue(t, p2HandAfter > p2HandBefore, "Player2 should receive cards from completion effect even without seats")
 }
 
 func TestFundSeat_NotCompleted_WhenSeatsRemain(t *testing.T) {
@@ -314,4 +299,99 @@ func TestFundSeat_NotCompleted_WhenSeatsRemain(t *testing.T) {
 
 	state := testGame.GetProjectFundingState("pf_orbital_station")
 	testutil.AssertFalse(t, state.IsCompleted, "Project should not be completed with seats remaining")
+}
+
+// --- Global Effect Tests ---
+
+func TestFundSeat_Completion_TerraformingHub_TRAndOxygen(t *testing.T) {
+	testGame, repo, pfRegistry, player1, player2 := setupProjectFundingGame(t)
+	ctx := context.Background()
+
+	// pf_terraforming_hub: completion gives +3 TR to all players + raises oxygen 2 steps
+	def, _ := pfRegistry.GetByID("pf_terraforming_hub")
+	// Use "other_player" for all preceding seats so P1 only owns the final seat (no tier reward)
+	owners := make([]string, len(def.Seats)-1)
+	for i := range owners {
+		owners[i] = "other_player"
+	}
+	setupProjectState(testGame, "pf_terraforming_hub", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	p2, _ := testGame.GetPlayer(player2)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	p1TRBefore := p1.Resources().TerraformRating()
+	p2TRBefore := p2.Resources().TerraformRating()
+	oxygenBefore := testGame.GlobalParameters().Oxygen()
+	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_terraforming_hub", pfAction.FundSeatPayment{Credits: lastSeatCost})
+	testutil.AssertNoError(t, err, "Buy last seat should succeed")
+
+	testutil.AssertEqual(t, p1TRBefore+5, p1.Resources().TerraformRating(), "P1 should gain +5 TR from completion")
+	testutil.AssertEqual(t, p2TRBefore+5, p2.Resources().TerraformRating(), "P2 should gain +5 TR from completion")
+	testutil.AssertEqual(t, oxygenBefore+2, testGame.GlobalParameters().Oxygen(), "Oxygen should increase by 2")
+}
+
+func TestFundSeat_Completion_ProductionChoice_SetForAllPlayers(t *testing.T) {
+	testGame, repo, pfRegistry, player1, player2 := setupProjectFundingGame(t)
+	ctx := context.Background()
+
+	// pf_solar_forge: completion gives each player production choice
+	def, _ := pfRegistry.GetByID("pf_solar_forge")
+	owners := make([]string, len(def.Seats)-1)
+	for i := range owners {
+		owners[i] = player1
+	}
+	setupProjectState(testGame, "pf_solar_forge", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	p2, _ := testGame.GetPlayer(player2)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_solar_forge", pfAction.FundSeatPayment{Credits: lastSeatCost})
+	testutil.AssertNoError(t, err, "Buy last seat should succeed")
+
+	p1Choice := p1.Selection().GetPendingBehaviorChoiceSelection()
+	p2Choice := p2.Selection().GetPendingBehaviorChoiceSelection()
+
+	testutil.AssertTrue(t, p1Choice != nil, "P1 should have pending production choice")
+	testutil.AssertTrue(t, p2Choice != nil, "P2 should have pending production choice")
+	testutil.AssertEqual(t, 6, len(p1Choice.Choices), "Should have 6 production type choices")
+	testutil.AssertEqual(t, "project-funding-completion", p1Choice.Source, "Source should be project-funding-completion")
+}
+
+func TestFundSeat_Completion_MassCardDraw(t *testing.T) {
+	testGame, repo, pfRegistry, player1, player2 := setupProjectFundingGame(t)
+	ctx := context.Background()
+
+	// pf_orbital_station: completion deals 20 cards to each player
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	owners := make([]string, len(def.Seats)-1)
+	for i := range owners {
+		owners[i] = player1
+	}
+	setupProjectState(testGame, "pf_orbital_station", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	p2, _ := testGame.GetPlayer(player2)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	p1HandBefore := len(p1.Hand().Cards())
+	p2HandBefore := len(p2.Hand().Cards())
+	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
+	testutil.AssertNoError(t, err, "Buy last seat should succeed")
+
+	p1HandAfter := len(p1.Hand().Cards())
+	p2HandAfter := len(p2.Hand().Cards())
+
+	testutil.AssertEqual(t, p1HandBefore+20, p1HandAfter, "P1 should receive 20 cards")
+	testutil.AssertEqual(t, p2HandBefore+20, p2HandAfter, "P2 should receive 20 cards")
 }

--- a/backend/test/projectfunding/loader_test.go
+++ b/backend/test/projectfunding/loader_test.go
@@ -12,7 +12,7 @@ const jsonPath = "../../assets/terraforming_mars_project_funding.json"
 func TestLoadProjectsFromJSON_Success(t *testing.T) {
 	defs, err := pfLoader.LoadProjectsFromJSON(jsonPath)
 	testutil.AssertNoError(t, err, "Should load projects from JSON")
-	testutil.AssertTrue(t, len(defs) >= 8, "Should have at least 8 projects")
+	testutil.AssertTrue(t, len(defs) >= 1, "Should have at least 1 project")
 }
 
 func TestLoadProjectsFromJSON_InvalidPath(t *testing.T) {
@@ -29,7 +29,8 @@ func TestLoadProjectsFromJSON_ValidatesStructure(t *testing.T) {
 		testutil.AssertTrue(t, def.Name != "", "Project name should not be empty")
 		testutil.AssertTrue(t, len(def.Seats) > 0, "Project should have at least 1 seat")
 		testutil.AssertTrue(t, len(def.RewardTiers) > 0, "Project should have at least 1 reward tier")
-		testutil.AssertTrue(t, len(def.CompletionEffect.Rewards) > 0, "Project should have completion rewards")
+		hasCompletionEffect := len(def.CompletionEffect.Rewards) > 0 || len(def.CompletionEffect.GlobalEffects) > 0
+		testutil.AssertTrue(t, hasCompletionEffect, "Project should have completion rewards or global effects")
 	}
 }
 

--- a/frontend/src/components/ui/popover/ProjectFundingPopover.tsx
+++ b/frontend/src/components/ui/popover/ProjectFundingPopover.tsx
@@ -7,6 +7,7 @@ import {
   ProjectFundingDto,
   ProjectSeatDto,
   ColonyOutputDto,
+  ProjectGlobalOutputDto,
 } from "@/types/generated/api-types.ts";
 import GameIcon from "../display/GameIcon.tsx";
 import { webSocketService } from "@/services/webSocketService.ts";
@@ -184,6 +185,15 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, canAct, onBuySeat })
 
       <div style={{ height: "1px", background: "rgba(255,255,255,0.15)", margin: "10px 0" }} />
 
+      {project.firstFunderBonus && project.firstFunderBonus.length > 0 && (
+        <div className="flex items-center gap-1.5 mb-2">
+          <span className="text-[10px] font-orbitron text-amber-400/70 uppercase tracking-wider">
+            First Funder
+          </span>
+          <OutputDisplay outputs={project.firstFunderBonus} />
+        </div>
+      )}
+
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <span className="text-[10px] font-orbitron text-white/40 uppercase tracking-wider">
@@ -203,7 +213,15 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, canAct, onBuySeat })
           <span className="text-[10px] font-orbitron text-white/40 uppercase tracking-wider">
             Completion
           </span>
-          <OutputDisplay outputs={project.completionEffect.rewards} />
+          <div className="flex flex-col items-end gap-0.5">
+            {project.completionEffect.rewards.length > 0 && (
+              <OutputDisplay outputs={project.completionEffect.rewards} />
+            )}
+            {project.completionEffect.globalEffects &&
+              project.completionEffect.globalEffects.length > 0 && (
+                <GlobalEffectsDisplay effects={project.completionEffect.globalEffects} />
+              )}
+          </div>
         </div>
       </div>
 
@@ -277,6 +295,39 @@ const OutputDisplay: React.FC<OutputDisplayProps> = ({ outputs }) => {
         );
       })}
     </span>
+  );
+};
+
+interface GlobalEffectsDisplayProps {
+  effects: ProjectGlobalOutputDto[];
+}
+
+const globalEffectLabel = (effect: ProjectGlobalOutputDto): string => {
+  switch (effect.type) {
+    case "freeze-turn-order":
+      return "Freeze turn order";
+    case "production-choice":
+      return `Each player: +${effect.amount} any production`;
+    case "card-draw":
+      return `Each player: +${effect.amount} cards`;
+    case "temperature":
+      return `+${effect.amount} temperature`;
+    case "oxygen":
+      return `+${effect.amount} oxygen`;
+    default:
+      return effect.type;
+  }
+};
+
+const GlobalEffectsDisplay: React.FC<GlobalEffectsDisplayProps> = ({ effects }) => {
+  return (
+    <div className="flex flex-col items-end gap-0.5">
+      {effects.map((effect, i) => (
+        <span key={i} className="text-[10px] font-orbitron text-purple-300/80">
+          {globalEffectLabel(effect)}
+        </span>
+      ))}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

- Replaces 10 randomly-selected projects with 3 fixed, high-impact projects always in play
- **Orbital Station** (6 seats, titanium payment on first 3): completion deals 20 cards to every player
- **Solar Forge** (5 seats): completion gives every player a choice of +10 production of any type
- **Terraforming Hub** (7 seats): completion gives every player +5 TR and raises oxygen 2 steps
- Fixes production-choice label in the popover (was hardcoded "+1", now reads the actual amount)

## Test plan

- [ ] Start a game with project funding enabled — confirm exactly 3 projects appear
- [ ] Complete Solar Forge → each player gets a choice of +10 production
- [ ] Complete Orbital Station → each player receives 20 cards
- [ ] Complete Terraforming Hub → all players gain +5 TR, oxygen raises 2 steps
- [ ] Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)