### PR TITLE
test: add tests for Pets card mechanics

### DIFF
--- a/backend/test/action/card_effects/passive_card_effects_test.go
+++ b/backend/test/action/card_effects/passive_card_effects_test.go
@@ -925,3 +925,194 @@ func TestArcticAlgae_DoesNotTriggerOnCityPlacement(t *testing.T) {
 	testutil.AssertEqual(t, plantsBefore, plantsAfter,
 		"Arctic Algae should NOT trigger on city placement")
 }
+
+// --- Pets (172) ---
+// "Effect: Add an animal to this card when any city is built."
+
+func TestPets_GainsAnimalWhenOtherPlayerPlacesCity(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	petsCard := gamecards.Card{
+		ID:              "card-pets",
+		Name:            "Pets",
+		Type:            gamecards.CardTypeActive,
+		Cost:            10,
+		Tags:            []shared.CardTag{shared.TagAnimal, shared.TagEarth},
+		ResourceStorage: &gamecards.ResourceStorage{Type: shared.ResourceAnimal, Starting: 0},
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{petsCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	other := players[1]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	other.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	owner.PlayedCards().AddCard("card-pets", "Pets", "active", []string{"animal", "earth"})
+
+	effect := shared.CardEffect{
+		CardID:        "card-pets",
+		CardName:      "Pets",
+		BehaviorIndex: 1,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:     "city-placed",
+						Location: testutil.StrPtr("anywhere"),
+						Target:   &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourceAnimal, Amount: 1, Target: "self-card"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	animalsBefore := owner.Resources().GetCardStorage("card-pets")
+
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: other.ID(),
+		TileType: string(shared.ResourceCityTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	animalsAfter := owner.Resources().GetCardStorage("card-pets")
+	testutil.AssertEqual(t, animalsBefore+1, animalsAfter,
+		"Pets should gain 1 animal when any player places a city")
+}
+
+func TestPets_GainsAnimalWhenSelfPlacesCity(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	petsCard := gamecards.Card{
+		ID:              "card-pets",
+		Name:            "Pets",
+		Type:            gamecards.CardTypeActive,
+		Cost:            10,
+		Tags:            []shared.CardTag{shared.TagAnimal, shared.TagEarth},
+		ResourceStorage: &gamecards.ResourceStorage{Type: shared.ResourceAnimal, Starting: 0},
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{petsCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	owner.PlayedCards().AddCard("card-pets", "Pets", "active", []string{"animal", "earth"})
+
+	effect := shared.CardEffect{
+		CardID:        "card-pets",
+		CardName:      "Pets",
+		BehaviorIndex: 1,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:     "city-placed",
+						Location: testutil.StrPtr("anywhere"),
+						Target:   &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourceAnimal, Amount: 1, Target: "self-card"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	animalsBefore := owner.Resources().GetCardStorage("card-pets")
+
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: owner.ID(),
+		TileType: string(shared.ResourceCityTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	animalsAfter := owner.Resources().GetCardStorage("card-pets")
+	testutil.AssertEqual(t, animalsBefore+1, animalsAfter,
+		"Pets should gain 1 animal when owner places a city")
+}
+
+func TestPets_DoesNotTriggerOnGreeneryPlacement(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, _ := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	anyPlayerTarget := "any-player"
+	petsCard := gamecards.Card{
+		ID:              "card-pets",
+		Name:            "Pets",
+		Type:            gamecards.CardTypeActive,
+		Cost:            10,
+		Tags:            []shared.CardTag{shared.TagAnimal, shared.TagEarth},
+		ResourceStorage: &gamecards.ResourceStorage{Type: shared.ResourceAnimal, Starting: 0},
+	}
+	cardRegistry := cards.NewInMemoryCardRegistry([]gamecards.Card{petsCard})
+
+	players := testGame.GetAllPlayers()
+	owner := players[0]
+	owner.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.StartTestGame(t, testGame)
+
+	owner.PlayedCards().AddCard("card-pets", "Pets", "active", []string{"animal", "earth"})
+
+	effect := shared.CardEffect{
+		CardID:        "card-pets",
+		CardName:      "Pets",
+		BehaviorIndex: 1,
+		Behavior: shared.CardBehavior{
+			Triggers: []shared.Trigger{
+				{
+					Type: shared.TriggerTypeAuto,
+					Condition: &shared.ResourceTriggerCondition{
+						Type:     "city-placed",
+						Location: testutil.StrPtr("anywhere"),
+						Target:   &anyPlayerTarget,
+					},
+				},
+			},
+			Outputs: []shared.ResourceCondition{
+				{ResourceType: shared.ResourceAnimal, Amount: 1, Target: "self-card"},
+			},
+		},
+	}
+	owner.Effects().AddEffect(effect)
+	action.SubscribePassiveEffectToEvents(ctx, testGame, owner, effect, logger, cardRegistry)
+
+	animalsBefore := owner.Resources().GetCardStorage("card-pets")
+
+	events.Publish(testGame.EventBus(), events.TilePlacedEvent{
+		GameID:   testGame.ID(),
+		PlayerID: owner.ID(),
+		TileType: string(shared.ResourceGreeneryTile),
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	animalsAfter := owner.Resources().GetCardStorage("card-pets")
+	testutil.AssertEqual(t, animalsBefore, animalsAfter,
+		"Pets should NOT gain animals on greenery placement")
+}

--- a/backend/test/action/card_packs/play_card_base_test.go
+++ b/backend/test/action/card_packs/play_card_base_test.go
@@ -64,6 +64,34 @@ func TestColonizerTrainingCamp_PlaysSuccessfully(t *testing.T) {
 		"Colonizer Training Camp should be in played cards")
 }
 
+// --- Pets (172) ---
+// "Effect: Add an animal to this card when any city is built. Add 1 animal to this card. 1 VP per 2 animals here."
+func TestPets_PlaysSuccessfully(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+	card := testutil.GetCardByName("Pets")
+	cardRegistry := testutil.CreateTestCardRegistry()
+	players := testGame.GetAllPlayers()
+	p := players[0]
+	p.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.AssertNoError(t, testGame.UpdateStatus(ctx, shared.GameStatusActive), "update status")
+	testutil.AssertNoError(t, testGame.UpdatePhase(ctx, shared.GamePhaseAction), "update phase")
+	testutil.AssertNoError(t, testGame.SetCurrentTurn(ctx, p.ID(), 2), "set current turn")
+	p.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit: 100,
+	})
+	p.Hand().AddCard(card.ID)
+	playCardAction := cardAction.NewPlayCardAction(repo, cardRegistry, nil, logger)
+	payment := cardAction.PaymentRequest{Credits: 10}
+	err := playCardAction.Execute(ctx, testGame.ID(), p.ID(), card.ID, payment, nil, nil, nil, nil)
+	testutil.AssertNoError(t, err, "Pets should play successfully")
+	testutil.AssertTrue(t, p.PlayedCards().Contains(card.ID), "Pets should be in played cards")
+	storage := p.Resources().GetCardStorage(card.ID)
+	testutil.AssertEqual(t, 1, storage, "Pets should have 1 initial animal on play")
+}
+
 // --- Deep Well Heating (003) ---
 // "Increase your energy production 1 step. Increase temperature 1 step."
 func TestDeepWellHeating_EnergyProductionAndTemperature(t *testing.T) {

--- a/backend/test/game/cards/vp_calculator_test.go
+++ b/backend/test/game/cards/vp_calculator_test.go
@@ -363,6 +363,104 @@ func TestNegativeVPReducesTotalScore(t *testing.T) {
 	}
 }
 
+// --- Pets (172) ---
+// "1 VP per 2 animals here."
+
+func TestPetsVP_ZeroAnimals(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	cardID := testutil.CardID("Pets")
+	p.PlayedCards().AddCard(cardID, "Pets", "active", []string{"animal", "earth"})
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+		nil,
+		nil,
+	)
+
+	if breakdown.CardVP != 0 {
+		t.Fatalf("expected CardVP=0 for Pets with 0 animals, got %d", breakdown.CardVP)
+	}
+}
+
+func TestPetsVP_OneAnimal(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	cardID := testutil.CardID("Pets")
+	p.PlayedCards().AddCard(cardID, "Pets", "active", []string{"animal", "earth"})
+	p.Resources().AddToStorage(cardID, 1)
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+		nil,
+		nil,
+	)
+
+	if breakdown.CardVP != 0 {
+		t.Fatalf("expected CardVP=0 for Pets with 1 animal (floor division), got %d", breakdown.CardVP)
+	}
+}
+
+func TestPetsVP_TwoAnimals(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	cardID := testutil.CardID("Pets")
+	p.PlayedCards().AddCard(cardID, "Pets", "active", []string{"animal", "earth"})
+	p.Resources().AddToStorage(cardID, 2)
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+		nil,
+		nil,
+	)
+
+	if breakdown.CardVP != 1 {
+		t.Fatalf("expected CardVP=1 for Pets with 2 animals, got %d", breakdown.CardVP)
+	}
+}
+
+func TestPetsVP_FiveAnimals(t *testing.T) {
+	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)
+	p, _ := g.GetPlayer(playerID)
+
+	cardID := testutil.CardID("Pets")
+	p.PlayedCards().AddCard(cardID, "Pets", "active", []string{"animal", "earth"})
+	p.Resources().AddToStorage(cardID, 5)
+
+	breakdown := gamecards.CalculatePlayerVP(
+		p,
+		g.Board(),
+		nil,
+		nil,
+		g.GetAllPlayers(),
+		cardRegistry,
+		nil,
+		nil,
+	)
+
+	if breakdown.CardVP != 2 {
+		t.Fatalf("expected CardVP=2 for Pets with 5 animals, got %d", breakdown.CardVP)
+	}
+}
+
 // TestNoVPCards verifies that cards without VP conditions don't contribute.
 func TestNoVPCards(t *testing.T) {
 	g, _, cardRegistry, playerID, _ := testutil.SetupTwoPlayerGame(t)


### PR DESCRIPTION
## Summary
- Add VP tests for Pets card (1 VP per 2 animals, including edge cases for 0, 1, 2, and 5 animals)
- Add play card test verifying Pets costs 10 MC and gets 1 initial animal on play
- Add passive trigger tests verifying the city-placement effect fires for any player's city (but not for greenery)

## Test plan
- [ ] `make test-verbose` passes
- [ ] `go test ./test/game/cards/... ./test/action/card_packs/... ./test/action/card_effects/... -run "Pets"` — all 8 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)