### PR TITLE
feat: add Luna Metropolis off-Mars city tile

### DIFF
--- a/backend/assets/terraforming_mars_cards.json
+++ b/backend/assets/terraforming_mars_cards.json
@@ -10342,7 +10342,7 @@
     "name": "Luna Metropolis",
     "type": "automated",
     "cost": 21,
-    "description": "Increase your M€ production 1 step for each Earth tag you have, including this. Build Ganymede Colony.",
+    "description": "Increase your M€ production 1 step for each Earth tag you have, including this. Build Luna Metropolis.",
     "pack": "venus-next",
     "tags": [
       "city",
@@ -10368,9 +10368,19 @@
               "target": "self-player",
               "tag": "earth"
             }
+          },
+          {
+            "type": "city-placement",
+            "amount": 1,
+            "target": "none",
+            "tileRestrictions": {
+              "boardTags": [
+                "luna-metropolis"
+              ]
+            }
           }
         ],
-        "description": "Increase your M€ production 1 step for each Earth tag you have, including this. Build Ganymede Colony."
+        "description": "Increase your M€ production 1 step for each Earth tag you have, including this. Build Luna Metropolis."
       }
     ],
     "vpConditions": [

--- a/backend/internal/game/board/board.go
+++ b/backend/internal/game/board/board.go
@@ -74,6 +74,7 @@ const (
 	BoardTagDawnCity         BoardTag = "dawn-city"
 	BoardTagMaxwellBase      BoardTag = "maxwell-base"
 	BoardTagStratopolis      BoardTag = "stratopolis"
+	BoardTagLunaMetropolis   BoardTag = "luna-metropolis"
 )
 
 // TileLocation represents the celestial body where tiles are located
@@ -289,6 +290,7 @@ func GenerateMarsBoard(includeVenus bool) []Tile {
 		{shared.HexPosition{Q: 0, R: -5, S: 5}, []string{BoardTagPhobosSpaceHaven}, "Phobos Space Haven"},
 		{shared.HexPosition{Q: -5, R: 0, S: 5}, []string{BoardTagDawnCity}, "Dawn City"},
 		{shared.HexPosition{Q: 5, R: -5, S: 0}, []string{BoardTagGanymedeColony}, "Ganymede Colony"},
+		{shared.HexPosition{Q: -5, R: 5, S: 0}, []string{BoardTagLunaMetropolis}, "Luna Metropolis"},
 	}
 	for _, ot := range offMarsTiles {
 		displayName := ot.DisplayName

--- a/backend/test/action/card_packs/play_card_venus_test.go
+++ b/backend/test/action/card_packs/play_card_venus_test.go
@@ -972,6 +972,29 @@ func TestLunaMetropolis_CreditProductionPerEarthTag(t *testing.T) {
 		"Credit production should increase by 3 (1 per earth tag: 2 existing + 1 from this card)")
 }
 
+func TestLunaMetropolis_PlacesCityTile(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 1, broadcaster)
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+	card := testutil.GetCardByName("Luna Metropolis")
+	cardRegistry := testutil.CreateTestCardRegistry()
+	players := testGame.GetAllPlayers()
+	p := players[0]
+	p.SetCorporationID(testutil.CardID("Tharsis Republic"))
+	testutil.AssertNoError(t, testGame.UpdateStatus(ctx, shared.GameStatusActive), "UpdateStatus failed")
+	testutil.AssertNoError(t, testGame.UpdatePhase(ctx, shared.GamePhaseAction), "UpdatePhase failed")
+	testutil.AssertNoError(t, testGame.SetCurrentTurn(ctx, p.ID(), 2), "SetCurrentTurn failed")
+	p.Resources().Add(map[shared.ResourceType]int{shared.ResourceCredit: 100})
+	p.Hand().AddCard(card.ID)
+	playCardAction := cardAction.NewPlayCardAction(repo, cardRegistry, nil, logger)
+	payment := cardAction.PaymentRequest{Credits: 21}
+	err := playCardAction.Execute(ctx, testGame.ID(), p.ID(), card.ID, payment, nil, nil, nil, nil)
+	testutil.AssertNoError(t, err, "Luna Metropolis should play successfully")
+	selection := testGame.GetPendingTileSelection(p.ID())
+	testutil.AssertTrue(t, selection != nil, "Should have pending city tile selection after playing Luna Metropolis")
+}
+
 // =============================================================================
 // Card 237: Luxury Foods (automated)
 // "Requires Venus, Earth and Jovian tags." No behaviors, just VP.

--- a/backend/test/game/board/board_tag_test.go
+++ b/backend/test/game/board/board_tag_test.go
@@ -65,9 +65,9 @@ func TestGenerateMarsBoard_UntaggedTilesHaveNoTags(t *testing.T) {
 		}
 	}
 
-	// Noctis City, 4 volcanic tiles, and 3 off-Mars tiles (Phobos, Dawn City, Ganymede Colony) should be tagged
-	if taggedCount != 8 {
-		t.Errorf("expected exactly 8 tagged tiles (Noctis City, 4 volcanic, 3 off-Mars), got %d", taggedCount)
+	// Noctis City, 4 volcanic tiles, and 4 off-Mars tiles (Phobos, Dawn City, Ganymede Colony, Luna Metropolis) should be tagged
+	if taggedCount != 9 {
+		t.Errorf("expected exactly 9 tagged tiles (Noctis City, 4 volcanic, 4 off-Mars), got %d", taggedCount)
 	}
 
 	// All other tiles should have empty tags
@@ -79,8 +79,8 @@ func TestGenerateMarsBoard_UntaggedTilesHaveNoTags(t *testing.T) {
 func TestGenerateMarsBoard_TotalTileCount(t *testing.T) {
 	tiles := board.GenerateMarsBoard(false)
 
-	// Standard Mars board with radius 4 has 61 hex tiles + 3 off-Mars tiles = 64
-	expectedCount := 64
+	// Standard Mars board with radius 4 has 61 hex tiles + 4 off-Mars tiles = 65
+	expectedCount := 65
 	if len(tiles) != expectedCount {
 		t.Errorf("expected %d tiles, got %d", expectedCount, len(tiles))
 	}


### PR DESCRIPTION
- Add `BoardTagLunaMetropolis` board tag and Luna Metropolis hex tile to the board
- Fix card description (was incorrectly referencing Ganymede Colony)
- Add city placement behavior restricted to the `luna-metropolis` hex
- Update board tag test counts (8→9 tagged tiles, 64→65 total)
- Add `TestLunaMetropolis_PlacesCityTile` test