### PR TITLE
fix: sort standard projects by cost and fix chat init on first load

### DIFF
--- a/frontend/src/components/ui/popover/StandardProjectPopover.tsx
+++ b/frontend/src/components/ui/popover/StandardProjectPopover.tsx
@@ -33,8 +33,9 @@ const StandardProjectPopover: React.FC<StandardProjectsPopoverProps> = ({
   const canExecuteProjects =
     isGameActive && isActionPhase && isCurrentPlayerTurn && canPerformActions(gameState);
 
-  const playerProjects: PlayerStandardProjectDto[] =
-    gameState?.currentPlayer?.standardProjects ?? [];
+  const playerProjects: PlayerStandardProjectDto[] = [
+    ...(gameState?.currentPlayer?.standardProjects ?? []),
+  ].sort((a, b) => (a.effectiveCost["credit"] ?? 0) - (b.effectiveCost["credit"] ?? 0));
 
   const handleProjectClick = (project: PlayerStandardProjectDto) => {
     if (!canExecuteProjects || !project.available) return;

--- a/frontend/src/hooks/useWebSocketConnection.ts
+++ b/frontend/src/hooks/useWebSocketConnection.ts
@@ -226,8 +226,8 @@ export function useWebSocketConnection(
         }
       }
 
-      if (!previousGameRef.current && updatedGame.chatMessages?.length) {
-        useGameStore.getState().setChatMessages(updatedGame.chatMessages);
+      if (!previousGameRef.current) {
+        useGameStore.getState().setChatMessages(updatedGame.chatMessages ?? []);
       }
 
       previousGameRef.current = deepClone(updatedGame);


### PR DESCRIPTION
- Sort standard projects by credit cost ascending in `StandardProjectPopover`
- Initialise chat messages to `[]` on first WebSocket connection (previously skipped if no messages, causing stale state)