### PR TITLE
fix: correct Nuke card tags for steel/titanium payment

### DIFF
--- a/backend/assets/terraforming_mars_cards.json
+++ b/backend/assets/terraforming_mars_cards.json
@@ -20207,7 +20207,8 @@
     "description": "Replace any non-ocean tile with a Nuclear Zone tile.",
     "pack": "experimental",
     "tags": [
-      "event",
+      "building",
+      "space",
       "earth"
     ],
     "behaviors": [

--- a/backend/test/action/card_packs/play_card_experimental_test.go
+++ b/backend/test/action/card_packs/play_card_experimental_test.go
@@ -116,6 +116,148 @@ func TestNuke_DoesNotTargetOceanTiles(t *testing.T) {
 		"City hex should be available for replacement")
 }
 
+func TestNuke_HasBuildingAndSpaceTags(t *testing.T) {
+	nukeCard := testutil.GetCardByName("Nuke")
+	testutil.AssertTrue(t, nukeCard.Tags != nil, "Nuke should have tags")
+
+	hasBuilding := false
+	hasSpace := false
+	hasEvent := false
+	for _, tag := range nukeCard.Tags {
+		switch tag {
+		case "building":
+			hasBuilding = true
+		case "space":
+			hasSpace = true
+		case "event":
+			hasEvent = true
+		}
+	}
+	testutil.AssertTrue(t, hasBuilding, "Nuke should have building tag")
+	testutil.AssertTrue(t, hasSpace, "Nuke should have space tag")
+	testutil.AssertTrue(t, !hasEvent, "Nuke should not have event tag (card type is already event)")
+}
+
+func TestNuke_PayWithSteel(t *testing.T) {
+	ctx := context.Background()
+	testGame, repo, _, playerIDs := testutil.SetupMultiPlayerGame(t, 2)
+	stateRepo := game.NewInMemoryGameStateRepository()
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+
+	p1ID := playerIDs[0]
+	p2ID := playerIDs[1]
+	p1, _ := testGame.GetPlayer(p1ID)
+
+	// Give player steel and some credits
+	p1.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit: 20,
+		shared.ResourceSteel:  5,
+	})
+
+	// Place a city so tile-replacement has a target
+	cityHex := testutil.FindUnoccupiedLandHex(t, testGame)
+	testutil.PlaceTileForPlayer(ctx, t, testGame, repo, p2ID, "city", cityHex)
+
+	err := testGame.SetCurrentTurn(ctx, p1ID, 2)
+	testutil.AssertNoError(t, err, "set turn")
+
+	nukeCard := testutil.GetCardByName("Nuke")
+	p1.Hand().AddCard(nukeCard.ID)
+
+	// Pay with 5 steel (5*2=10) + 20 credits = 30
+	playCard := cardAction.NewPlayCardAction(repo, cardRegistry, stateRepo, logger)
+	payment := cardAction.PaymentRequest{Credits: 20, Steel: 5}
+	err = playCard.Execute(ctx, testGame.ID(), p1ID, nukeCard.ID, payment, nil, nil, nil, nil)
+	testutil.AssertNoError(t, err, "Nuke should accept steel payment (building tag)")
+
+	resources := p1.Resources().Get()
+	testutil.AssertEqual(t, 0, resources.Steel, "Steel should be spent")
+}
+
+func TestNuke_PayWithTitanium(t *testing.T) {
+	ctx := context.Background()
+	testGame, repo, _, playerIDs := testutil.SetupMultiPlayerGame(t, 2)
+	stateRepo := game.NewInMemoryGameStateRepository()
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+
+	p1ID := playerIDs[0]
+	p2ID := playerIDs[1]
+	p1, _ := testGame.GetPlayer(p1ID)
+
+	// Give player titanium and some credits
+	p1.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit:   21,
+		shared.ResourceTitanium: 3,
+	})
+
+	// Place a city so tile-replacement has a target
+	cityHex := testutil.FindUnoccupiedLandHex(t, testGame)
+	testutil.PlaceTileForPlayer(ctx, t, testGame, repo, p2ID, "city", cityHex)
+
+	err := testGame.SetCurrentTurn(ctx, p1ID, 2)
+	testutil.AssertNoError(t, err, "set turn")
+
+	nukeCard := testutil.GetCardByName("Nuke")
+	p1.Hand().AddCard(nukeCard.ID)
+
+	// Pay with 3 titanium (3*3=9) + 21 credits = 30
+	playCard := cardAction.NewPlayCardAction(repo, cardRegistry, stateRepo, logger)
+	payment := cardAction.PaymentRequest{Credits: 21, Titanium: 3}
+	err = playCard.Execute(ctx, testGame.ID(), p1ID, nukeCard.ID, payment, nil, nil, nil, nil)
+	testutil.AssertNoError(t, err, "Nuke should accept titanium payment (space tag)")
+
+	resources := p1.Resources().Get()
+	testutil.AssertEqual(t, 0, resources.Titanium, "Titanium should be spent")
+}
+
+func TestNuke_PayWithBothSteelAndTitanium(t *testing.T) {
+	ctx := context.Background()
+	testGame, repo, _, playerIDs := testutil.SetupMultiPlayerGame(t, 2)
+	stateRepo := game.NewInMemoryGameStateRepository()
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+
+	p1ID := playerIDs[0]
+	p2ID := playerIDs[1]
+	p1, _ := testGame.GetPlayer(p1ID)
+
+	// Give player both steel and titanium
+	p1.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit:   11,
+		shared.ResourceSteel:    3,
+		shared.ResourceTitanium: 4,
+	})
+
+	// Place a city so tile-replacement has a target
+	cityHex := testutil.FindUnoccupiedLandHex(t, testGame)
+	testutil.PlaceTileForPlayer(ctx, t, testGame, repo, p2ID, "city", cityHex)
+
+	err := testGame.SetCurrentTurn(ctx, p1ID, 2)
+	testutil.AssertNoError(t, err, "set turn")
+
+	nukeCard := testutil.GetCardByName("Nuke")
+	p1.Hand().AddCard(nukeCard.ID)
+
+	// Pay with 3 steel (3*2=6) + 4 titanium (4*3=12) + 12 credits = 30
+	// Wait: 6 + 12 + 11 = 29, need 30. Adjust: 12 credits
+	// Actually: 3*2=6 + 4*3=12 + 12 = 30. Give 12 credits.
+	p1.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit: 1, // now 12 total
+	})
+
+	playCard := cardAction.NewPlayCardAction(repo, cardRegistry, stateRepo, logger)
+	payment := cardAction.PaymentRequest{Credits: 12, Steel: 3, Titanium: 4}
+	err = playCard.Execute(ctx, testGame.ID(), p1ID, nukeCard.ID, payment, nil, nil, nil, nil)
+	testutil.AssertNoError(t, err, "Nuke should accept both steel and titanium payment (building + space tags)")
+
+	resources := p1.Resources().Get()
+	testutil.AssertEqual(t, 0, resources.Steel, "Steel should be spent")
+	testutil.AssertEqual(t, 0, resources.Titanium, "Titanium should be spent")
+	testutil.AssertEqual(t, 0, resources.Credits, "Credits should be spent")
+}
+
 func TestNuke_HasNegativeVP(t *testing.T) {
 	nukeCard := testutil.GetCardByName("Nuke")
 	testutil.AssertTrue(t, len(nukeCard.VPConditions) > 0, "Nuke should have VP conditions")


### PR DESCRIPTION
## Summary
- Removed redundant `event` tag from Nuke (EXP004) — card type is already `event`
- Added `building` and `space` tags so the card can be paid with steel and titanium
- Tags changed from `["event", "earth"]` to `["building", "space", "earth"]`

## Test plan
- [x] `TestNuke_HasBuildingAndSpaceTags` — verifies correct tags and no event tag
- [x] `TestNuke_PayWithSteel` — steel payment accepted (building tag)
- [x] `TestNuke_PayWithTitanium` — titanium payment accepted (space tag)
- [x] `TestNuke_PayWithBothSteelAndTitanium` — combined payment works
- [x] All existing Nuke tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)