### PR TITLE
fix: prevent playing cards while spectating another player

### DIFF
--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -972,7 +972,7 @@ export default function GameInterface() {
               cards={replayViewAsPlayer?.cards ?? currentPlayer?.cards ?? []}
               hideWhenModalOpen={hideCardFanForModals}
               onCardSelect={(_cardId) => {}}
-              onPlayCard={flow.handlePlayCard}
+              onPlayCard={spectatePlayerId ? undefined : flow.handlePlayCard}
             />
           </div>
         )}

--- a/frontend/src/hooks/useCardPlayFlow.ts
+++ b/frontend/src/hooks/useCardPlayFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import { useGameStore } from "@/stores/gameStore.ts";
 import { useCardPlayFlowStore } from "@/stores/cardPlayFlowStore.ts";
+import { useSpectateStore } from "@/stores/spectateStore.ts";
 import { globalWebSocketManager } from "@/services/globalWebSocketManager.ts";
 import { shouldShowPaymentModal, createDefaultPayment } from "@/utils/paymentUtils.ts";
 import { StandardProject } from "@/types/cards.tsx";
@@ -110,6 +111,10 @@ export function useCardPlayFlow() {
         const g = useGameStore.getState().game;
         const cp = useGameStore.getState().currentPlayer;
         const store = useCardPlayFlowStore.getState();
+
+        if (useSpectateStore.getState().spectatePlayerId) {
+          return;
+        }
 
         if (g?.currentTurn !== g?.viewingPlayerId) {
           throw new Error("Not your turn");


### PR DESCRIPTION
## Summary
- Fixes #482 — players could drag-to-throw cards from the card fan while spectating another player
- Root cause: `.card-fan-card { pointer-events: auto }` overrode the parent wrapper's `pointer-events: none`
- Disables `onPlayCard` callback on CardFanOverlay when spectating, plus defense-in-depth check in `handlePlayCard`

## Test plan
- [ ] Start a multiplayer game, click another player to spectate
- [ ] Verify card fan cannot be interacted with (no drag-to-throw)
- [ ] Stop spectating and verify cards work normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)