### PR TITLE
fix: add prelude card plays to game log

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -224,7 +224,7 @@ func main() {
 	// Turn management (4)
 	skipActionAction := turnAction.NewSkipActionAction(gameRepo, finalScoringAction, log)
 	selectStartingChoicesAction := turnAction.NewSelectStartingChoicesAction(gameRepo, cardRegistry, awardRegistry, log)
-	confirmInitAdvanceAction := turnAction.NewConfirmInitAdvanceAction(gameRepo, cardRegistry, awardRegistry, log)
+	confirmInitAdvanceAction := turnAction.NewConfirmInitAdvanceAction(gameRepo, cardRegistry, awardRegistry, stateRepo, log)
 
 	// Bot service
 	commandDispatcher := bot.NewCommandDispatcher(

--- a/backend/internal/action/confirmation/confirm_card_draw.go
+++ b/backend/internal/action/confirmation/confirm_card_draw.go
@@ -121,7 +121,7 @@ func (a *ConfirmCardDrawAction) Execute(ctx context.Context, gameID string, play
 	if selection.PlayAsPrelude {
 		// Play selected prelude cards instead of adding to hand
 		for _, preludeID := range allSelectedCards {
-			if err := turn_management.ApplyPreludeCard(ctx, g, p, preludeID, a.CardRegistry(), log); err != nil {
+			if err := turn_management.ApplyPreludeCard(ctx, g, p, preludeID, a.CardRegistry(), a.StateRepository(), log); err != nil {
 				return fmt.Errorf("failed to play prelude card %s: %w", preludeID, err)
 			}
 		}

--- a/backend/internal/action/turn_management/confirm_init_advance.go
+++ b/backend/internal/action/turn_management/confirm_init_advance.go
@@ -20,6 +20,7 @@ type ConfirmInitAdvanceAction struct {
 	gameRepo      game.GameRepository
 	cardRegistry  cards.CardRegistry
 	awardRegistry awards.AwardRegistry
+	stateRepo     game.GameStateRepository
 	corpProc      *gamecards.CorporationProcessor
 	logger        *zap.Logger
 }
@@ -29,12 +30,14 @@ func NewConfirmInitAdvanceAction(
 	gameRepo game.GameRepository,
 	cardRegistry cards.CardRegistry,
 	awardRegistry awards.AwardRegistry,
+	stateRepo game.GameStateRepository,
 	logger *zap.Logger,
 ) *ConfirmInitAdvanceAction {
 	return &ConfirmInitAdvanceAction{
 		gameRepo:      gameRepo,
 		cardRegistry:  cardRegistry,
 		awardRegistry: awardRegistry,
+		stateRepo:     stateRepo,
 		corpProc:      gamecards.NewCorporationProcessor(cardRegistry, awardRegistry, logger),
 		logger:        logger,
 	}
@@ -121,7 +124,7 @@ func (a *ConfirmInitAdvanceAction) applyCurrentPlayer(ctx context.Context, g *ga
 		log.Debug("Applied corp effects", zap.String("player_id", currentPlayerID))
 
 	case shared.GamePhaseInitApplyPrelude:
-		if err := ApplyPreludesForPlayer(ctx, g, currentPlayerID, a.cardRegistry, log); err != nil {
+		if err := ApplyPreludesForPlayer(ctx, g, currentPlayerID, a.cardRegistry, a.stateRepo, log); err != nil {
 			return fmt.Errorf("failed to apply preludes for player %s: %w", currentPlayerID, err)
 		}
 		log.Debug("Applied prelude effects", zap.String("player_id", currentPlayerID))

--- a/backend/internal/action/turn_management/select_starting_choices.go
+++ b/backend/internal/action/turn_management/select_starting_choices.go
@@ -414,7 +414,7 @@ func ApplyCorpForPlayer(ctx context.Context, g *game.Game, playerID string, card
 
 // ApplyPreludesForPlayer applies all prelude card effects for a single player
 // during the init_apply_prelude phase.
-func ApplyPreludesForPlayer(ctx context.Context, g *game.Game, playerID string, cardRegistry cards.CardRegistry, log *zap.Logger) error {
+func ApplyPreludesForPlayer(ctx context.Context, g *game.Game, playerID string, cardRegistry cards.CardRegistry, stateRepo game.GameStateRepository, log *zap.Logger) error {
 	choices := g.GetDeferredStartingChoices(playerID)
 	if choices == nil {
 		return fmt.Errorf("no deferred starting choices for player %s", playerID)
@@ -434,7 +434,7 @@ func ApplyPreludesForPlayer(ctx context.Context, g *game.Game, playerID string, 
 		zap.Strings("preludes", choices.PreludeIDs))
 
 	for _, preludeID := range choices.PreludeIDs {
-		if err := ApplyPreludeCard(ctx, g, p, preludeID, cardRegistry, log); err != nil {
+		if err := ApplyPreludeCard(ctx, g, p, preludeID, cardRegistry, stateRepo, log); err != nil {
 			return fmt.Errorf("failed to apply prelude %s: %w", preludeID, err)
 		}
 	}
@@ -447,7 +447,7 @@ func ApplyPreludesForPlayer(ctx context.Context, g *game.Game, playerID string, 
 
 // ApplyPreludeCard applies a single prelude card's effects: adds to played cards,
 // processes auto behaviors, registers trigger effects and manual actions.
-func ApplyPreludeCard(ctx context.Context, g *game.Game, p *player.Player, preludeID string, cardRegistry cards.CardRegistry, log *zap.Logger) error {
+func ApplyPreludeCard(ctx context.Context, g *game.Game, p *player.Player, preludeID string, cardRegistry cards.CardRegistry, stateRepo game.GameStateRepository, log *zap.Logger) error {
 	card, err := cardRegistry.GetByID(preludeID)
 	if err != nil {
 		return fmt.Errorf("prelude card not found: %s", preludeID)
@@ -523,6 +523,14 @@ func ApplyPreludeCard(ctx context.Context, g *game.Game, p *player.Player, prelu
 			BehaviorIndex: behaviorIndex,
 			Behavior:      behavior,
 		})
+	}
+
+	if stateRepo != nil {
+		description := fmt.Sprintf("Played prelude %s", card.Name)
+		displayData := baseaction.BuildCardDisplayData(card, shared.SourceTypeCardPlay)
+		if _, err := stateRepo.WriteFull(ctx, g.ID(), g, card.Name, shared.SourceTypeCardPlay, p.ID(), description, nil, nil, displayData); err != nil {
+			log.Warn("Failed to write prelude state log", zap.String("card", card.Name), zap.Error(err))
+		}
 	}
 
 	return nil

--- a/backend/test/action/game_lifecycle/init_phase_test.go
+++ b/backend/test/action/game_lifecycle/init_phase_test.go
@@ -62,6 +62,7 @@ func completeAllSelections(
 		gameRepoWithGame(t, testGame),
 		cardRegistry,
 		nil,
+		nil,
 		logger,
 	)
 }
@@ -198,6 +199,7 @@ func TestInitPhase_RejectConfirmWrongPhase(t *testing.T) {
 		gameRepoWithGame(t, testGame),
 		cardRegistry,
 		nil,
+		nil,
 		logger,
 	)
 
@@ -287,6 +289,7 @@ func TestInitPhase_LastPlayerForcedTilePlacement(t *testing.T) {
 	confirmAction := turnAction.NewConfirmInitAdvanceAction(
 		gameRepoWithGame(t, testGame),
 		cardRegistry,
+		nil,
 		nil,
 		logger,
 	)


### PR DESCRIPTION
## Summary
- Fixes #491 — prelude cards were not appearing in the game log
- Root cause: `ApplyPreludeCard()` never called `stateRepo.WriteFull()`, so no log entries were created
- Added `stateRepo` to `ConfirmInitAdvanceAction` and threaded it through to `ApplyPreludeCard`, which now writes a log entry after applying each prelude card
- Also fixed the call in `confirm_card_draw.go` which uses `ApplyPreludeCard` for mid-game prelude plays

## Test plan
- [ ] Start a game with prelude cards enabled
- [ ] Complete starting selection and apply preludes
- [ ] Open the game log — prelude card plays should now appear
- [ ] Verify regular card plays still appear in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)