### PR TITLE
fix: reset chat messages when switching games

### DIFF
--- a/frontend/src/hooks/useWebSocketConnection.ts
+++ b/frontend/src/hooks/useWebSocketConnection.ts
@@ -230,7 +230,7 @@ export function useWebSocketConnection(
         }
       }
 
-      if (!previousGameRef.current) {
+      if (!previousGameRef.current || previousGameRef.current.id !== updatedGame.id) {
         useGameStore.getState().setChatMessages(updatedGame.chatMessages ?? []);
       }
 


### PR DESCRIPTION
## Summary
- Fixes #458 — chat messages from a previous game carried over to new games
- Root cause: chat was only initialized from backend data on the first `game-updated` event (`!previousGameRef.current`); subsequent game joins never reset it
- Fix: also reset chat when the game ID changes (`previousGameRef.current.id !== updatedGame.id`)

## Test plan
- [ ] Join a game, send some chat messages
- [ ] Leave and join a different game
- [ ] Verify chat is empty (no messages from previous game)
- [ ] Verify new messages in the new game work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)