### PR TITLE
fix: use echo instead of heredoc for coverage JSON

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,9 @@
-name: Coverage
+name: Coverage Report
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   pages: write


### PR DESCRIPTION
- Replace cat heredoc with echo to avoid trailing newline issues
- Keeps JSON output on a single line for consistent badge rendering