### PR TITLE
ci: trigger build workflows on version tags

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Backend Tests"]
     types: [completed]
     branches: [main]
+  push:
+    tags: ['v*']
   workflow_dispatch:
 
 env:
@@ -14,7 +16,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Frontend CI"]
     types: [completed]
     branches: [main]
+  push:
+    tags: ['v*']
   workflow_dispatch:
 
 env:
@@ -14,7 +16,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
- Add `push` trigger for `v*` tags to both build workflows
- Update `if` conditions to allow tag-pushed builds to run