### PR TITLE
fix: include colony selection in hasPendingTiles during init phase

### DIFF
--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -178,6 +178,11 @@ func ToGameDtoFull(g *game.Game, cardRegistry cards.CardRegistry, playerID strin
 		if currentInitPlayerID != "" {
 			hasPendingTiles = g.GetPendingTileSelection(currentInitPlayerID) != nil ||
 				g.GetPendingTileSelectionQueue(currentInitPlayerID) != nil
+			if !hasPendingTiles {
+				if initPlayer, err := g.GetPlayer(currentInitPlayerID); err == nil {
+					hasPendingTiles = initPlayer.Selection().GetPendingColonySelection() != nil
+				}
+			}
 		}
 
 		initPhaseDto = &InitPhaseDto{

--- a/backend/internal/delivery/dto/mapper_spectator.go
+++ b/backend/internal/delivery/dto/mapper_spectator.go
@@ -109,6 +109,11 @@ func ToSpectatorGameDto(g *game.Game, cardRegistry cards.CardRegistry, awardRegi
 		if currentInitPlayerID != "" {
 			hasPendingTiles = g.GetPendingTileSelection(currentInitPlayerID) != nil ||
 				g.GetPendingTileSelectionQueue(currentInitPlayerID) != nil
+			if !hasPendingTiles {
+				if initPlayer, err := g.GetPlayer(currentInitPlayerID); err == nil {
+					hasPendingTiles = initPlayer.Selection().GetPendingColonySelection() != nil
+				}
+			}
 		}
 
 		initPhaseDto = &InitPhaseDto{


### PR DESCRIPTION
## Summary

- `hasPendingTiles` in `InitPhaseDto` only checked hex tile selections (`PendingTileSelection` / `PendingTileSelectionQueue`), excluding colony selections
- For Poseidon's forced first action, this caused the init phase auto-confirm to fire while the colony placement was still pending, advancing the game too early
- The player was then stuck: colony placed (often in the wrong phase), but the init auto-confirm never re-triggered

## Fix

Added `PendingColonySelection` to the `hasPendingTiles` computation in both `mapper_game.go` and `mapper_spectator.go`. The frontend uses `hasPendingTiles` to decide whether to block the init-phase auto-confirm, so it now correctly waits for the colony placement before advancing.

Note: `confirm_init_advance.go` already covers this on `main` via `HasAnyPendingSelection` (which includes colony selection) — no backend action change needed.

## Test plan

- [ ] Start a game with Poseidon as the corporation
- [ ] In `init_apply_corp`, the colony selection overlay should appear and the game should NOT auto-advance before the colony is placed
- [ ] Place a colony — overlay closes, game auto-advances after ~750 ms
- [ ] Verify the action phase starts normally with Poseidon's actions available