### PR TITLE
feat: projected Score graph + Global Parameters as % completed

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -32,6 +32,7 @@ import (
 	"terraforming-mars-backend/internal/delivery/websocket/core"
 	"terraforming-mars-backend/internal/game"
 	"terraforming-mars-backend/internal/game/datastore"
+	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/internal/logger"
 	httpmiddleware "terraforming-mars-backend/internal/middleware/http"
 	msLoader "terraforming-mars-backend/internal/milestones"
@@ -155,6 +156,17 @@ func main() {
 	rm := datastore.NewRuntimeManager()
 	gameRepo := game.NewMemDBGameRepository(ds, rm)
 	log.Debug("Game repository initialized")
+
+	// Per-snapshot VP enrichment. Uses the same ComputePlayerVPBreakdowns helper as
+	// FinalScoringAction so the projected score on each history entry matches the
+	// scoreboard formula exactly.
+	ds.SetSnapshotEnricher(func(state *datastore.GameState) map[string]shared.VPBreakdown {
+		g, err := gameRepo.Get(context.Background(), state.ID)
+		if err != nil || g == nil {
+			return nil
+		}
+		return gameAction.ComputePlayerVPBreakdowns(g, cardRegistry, awardRegistry, milestoneRegistry)
+	})
 
 	// ========== Initialize Game State Repository (Diff Logging) ==========
 	stateRepo := game.NewInMemoryGameStateRepository()

--- a/backend/internal/action/game/final_scoring.go
+++ b/backend/internal/action/game/final_scoring.go
@@ -46,7 +46,7 @@ func NewFinalScoringAction(
 type PlayerScore struct {
 	PlayerID   string
 	PlayerName string
-	Breakdown  gamecards.VPBreakdown
+	Breakdown  shared.VPBreakdown
 	Credits    int // For tiebreaker
 }
 
@@ -75,23 +75,13 @@ func (a *FinalScoringAction) Execute(ctx context.Context, gameID string) error {
 		return nil
 	}
 
-	// 4. Prepare milestone and award data for VP calculation
-	claimedMilestones := convertToClaimedMilestoneInfo(g.Milestones().ClaimedMilestones())
-	fundedAwards := convertToFundedAwardInfo(g.Awards().FundedAwards())
+	// 4. Compute VP breakdowns via the shared single-source-of-truth helper.
+	breakdowns := ComputePlayerVPBreakdowns(g, a.cardRegistry, a.awardRegistry, a.milestoneRegistry)
 
-	// 5. Calculate VP for each player
+	// 5. Build PlayerScore entries for sorting.
 	scores := make([]PlayerScore, len(allPlayers))
 	for i, p := range allPlayers {
-		breakdown := gamecards.CalculatePlayerVP(
-			p,
-			g,
-			claimedMilestones,
-			fundedAwards,
-			allPlayers,
-			a.cardRegistry,
-			a.awardRegistry,
-			a.milestoneRegistry,
-		)
+		breakdown := breakdowns[p.ID()]
 		scores[i] = PlayerScore{
 			PlayerID:   p.ID(),
 			PlayerName: p.Name(),
@@ -137,27 +127,16 @@ func (a *FinalScoringAction) Execute(ctx context.Context, gameID string) error {
 		zap.Bool("is_tie", isTie),
 	)
 
-	// 8. Convert to shared.FinalScore and store in game
+	// 8. Build shared.FinalScore entries and store in game.
 	finalScores := make([]shared.FinalScore, len(scores))
 	for i, s := range scores {
 		finalScores[i] = shared.FinalScore{
 			PlayerID:   s.PlayerID,
 			PlayerName: s.PlayerName,
-			Breakdown: shared.VPBreakdown{
-				TerraformRating:   s.Breakdown.TerraformRating,
-				CardVP:            s.Breakdown.CardVP,
-				CardVPDetails:     convertCardVPDetails(s.Breakdown.CardVPDetails),
-				MilestoneVP:       s.Breakdown.MilestoneVP,
-				AwardVP:           s.Breakdown.AwardVP,
-				GreeneryVP:        s.Breakdown.GreeneryVP,
-				GreeneryVPDetails: convertGreeneryVPDetails(s.Breakdown.GreeneryVPDetails),
-				CityVP:            s.Breakdown.CityVP,
-				CityVPDetails:     convertCityVPDetails(s.Breakdown.CityVPDetails),
-				TotalVP:           s.Breakdown.TotalVP,
-			},
-			Credits:   s.Credits,
-			Placement: i + 1, // 1-indexed placement
-			IsWinner:  s.PlayerID == winnerID,
+			Breakdown:  s.Breakdown,
+			Credits:    s.Credits,
+			Placement:  i + 1, // 1-indexed placement
+			IsWinner:   s.PlayerID == winnerID,
 		}
 	}
 	err = g.SetFinalScores(ctx, finalScores, winnerID, isTie)

--- a/backend/internal/action/game/vp_breakdowns.go
+++ b/backend/internal/action/game/vp_breakdowns.go
@@ -1,0 +1,54 @@
+package game
+
+import (
+	"terraforming-mars-backend/internal/awards"
+	"terraforming-mars-backend/internal/cards"
+	"terraforming-mars-backend/internal/game"
+	gamecards "terraforming-mars-backend/internal/game/cards"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/internal/milestones"
+)
+
+// ComputePlayerVPBreakdowns is the single source of truth for per-player VP
+// breakdowns. Both FinalScoringAction (game end) and the history snapshot enricher
+// (per-snapshot projected score) call this so any future VP rule change applies
+// to both code paths automatically.
+func ComputePlayerVPBreakdowns(
+	g *game.Game,
+	cardRegistry cards.CardRegistry,
+	awardRegistry awards.AwardRegistry,
+	milestoneRegistry milestones.MilestoneRegistry,
+) map[string]shared.VPBreakdown {
+	allPlayers := g.GetAllPlayers()
+	if len(allPlayers) == 0 {
+		return nil
+	}
+
+	claimedMilestones := convertToClaimedMilestoneInfo(g.Milestones().ClaimedMilestones())
+	fundedAwards := convertToFundedAwardInfo(g.Awards().FundedAwards())
+
+	out := make(map[string]shared.VPBreakdown, len(allPlayers))
+	for _, p := range allPlayers {
+		breakdown := gamecards.CalculatePlayerVP(
+			p, g, claimedMilestones, fundedAwards, allPlayers,
+			cardRegistry, awardRegistry, milestoneRegistry,
+		)
+		out[p.ID()] = toSharedVPBreakdown(breakdown)
+	}
+	return out
+}
+
+func toSharedVPBreakdown(b gamecards.VPBreakdown) shared.VPBreakdown {
+	return shared.VPBreakdown{
+		TerraformRating:   b.TerraformRating,
+		CardVP:            b.CardVP,
+		CardVPDetails:     convertCardVPDetails(b.CardVPDetails),
+		MilestoneVP:       b.MilestoneVP,
+		AwardVP:           b.AwardVP,
+		GreeneryVP:        b.GreeneryVP,
+		GreeneryVPDetails: convertGreeneryVPDetails(b.GreeneryVPDetails),
+		CityVP:            b.CityVP,
+		CityVPDetails:     convertCityVPDetails(b.CityVPDetails),
+		TotalVP:           b.TotalVP,
+	}
+}

--- a/backend/internal/delivery/dto/mapper_game_history.go
+++ b/backend/internal/delivery/dto/mapper_game_history.go
@@ -1,9 +1,7 @@
 package dto
 
 import (
-	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
-	"terraforming-mars-backend/internal/game/shared"
 )
 
 // ToGameHistoryEntryDtos converts a slice of history entries to DTOs.
@@ -44,11 +42,15 @@ func toGameHistoryEntryDto(entry *datastore.GameStateHistoryEntry) GameHistoryEn
 
 	players := make(map[string]GameHistoryPlayerDto, len(s.Players))
 	for id, p := range s.Players {
-		cardVP := computeHistoryCardVP(p)
-		greeneryVP := computeHistoryGreeneryVP(s.Tiles, id)
-		cityVP := computeHistoryCityVP(s.Tiles, id)
-		milestoneVP := computeHistoryMilestoneVP(s.ClaimedMilestones, id)
-		totalVP := p.TerraformRating + cardVP + greeneryVP + cityVP + milestoneVP
+		// totalVP comes from the snapshot enricher in main.go, which calls
+		// gameAction.ComputePlayerVPBreakdowns — the same helper FinalScoringAction
+		// uses. If the enricher wasn't wired (legacy entries, tests), totalVP is 0.
+		totalVP := 0
+		if entry.VPBreakdowns != nil {
+			if breakdown, ok := entry.VPBreakdowns[id]; ok {
+				totalVP = breakdown.TotalVP
+			}
+		}
 
 		players[id] = GameHistoryPlayerDto{
 			ID:              p.ID,
@@ -109,50 +111,4 @@ func toGameHistoryEntryDto(entry *datastore.GameStateHistoryEntry) GameHistoryEn
 			CardPacks:        s.Settings.CardPacks,
 		},
 	}
-}
-
-func computeHistoryCardVP(p *datastore.PlayerState) int {
-	vp := 0
-	for _, g := range p.VPGranters {
-		vp += g.ComputedValue
-	}
-	return vp
-}
-
-func computeHistoryGreeneryVP(tiles []board.Tile, playerID string) int {
-	vp := 0
-	for _, t := range tiles {
-		if t.OccupiedBy != nil && shared.IsForestTile(t.OccupiedBy.Type) && t.OwnerID != nil && *t.OwnerID == playerID {
-			vp++
-		}
-	}
-	return vp
-}
-
-func computeHistoryCityVP(tiles []board.Tile, playerID string) int {
-	vp := 0
-	for _, t := range tiles {
-		if t.OccupiedBy == nil || t.OccupiedBy.Type != shared.ResourceCityTile || t.OwnerID == nil || *t.OwnerID != playerID {
-			continue
-		}
-		for _, neighbor := range t.Coordinates.GetNeighbors() {
-			for _, n := range tiles {
-				if n.Coordinates == neighbor && n.OccupiedBy != nil && shared.IsForestTile(n.OccupiedBy.Type) {
-					vp++
-					break
-				}
-			}
-		}
-	}
-	return vp
-}
-
-func computeHistoryMilestoneVP(milestones []shared.ClaimedMilestone, playerID string) int {
-	vp := 0
-	for _, m := range milestones {
-		if m.PlayerID == playerID {
-			vp += 5
-		}
-	}
-	return vp
 }

--- a/backend/internal/game/datastore/datastore.go
+++ b/backend/internal/game/datastore/datastore.go
@@ -22,6 +22,7 @@ type DataStore struct {
 	historySeqMu    sync.Mutex
 	historySequence map[string]int64 // per-game sequence counter
 	enricher        SnapshotEnricher
+	enricherWG      sync.WaitGroup
 }
 
 func NewDataStore() (*DataStore, error) {
@@ -39,6 +40,13 @@ func NewDataStore() (*DataStore, error) {
 // Pass nil to disable enrichment.
 func (ds *DataStore) SetSnapshotEnricher(fn SnapshotEnricher) {
 	ds.enricher = fn
+}
+
+// WaitForPendingEnrichments blocks until all in-flight enrichment goroutines
+// have completed. Tests can use this to read history entries that include
+// VPBreakdowns deterministically.
+func (ds *DataStore) WaitForPendingEnrichments() {
+	ds.enricherWG.Wait()
 }
 
 func (ds *DataStore) GetGame(gameID string) (*GameState, error) {
@@ -114,21 +122,63 @@ func (ds *DataStore) appendHistory(state *GameState) {
 	seq := ds.historySequence[state.ID]
 	ds.historySeqMu.Unlock()
 
-	var vpBreakdowns map[string]shared.VPBreakdown
-	if ds.enricher != nil {
-		vpBreakdowns = ds.enricher(state)
-	}
-
 	entry := &GameStateHistoryEntry{
-		GameID:       state.ID,
-		Sequence:     seq,
-		Timestamp:    time.Now(),
-		State:        copied,
-		VPBreakdowns: vpBreakdowns,
+		GameID:    state.ID,
+		Sequence:  seq,
+		Timestamp: time.Now(),
+		State:     copied,
 	}
 
 	htxn := ds.db.Txn(true)
 	_ = htxn.Insert("game_history", entry)
+	htxn.Commit()
+
+	// Enrichment runs asynchronously: callers of UpdateGame frequently hold
+	// game-level locks (e.g. game.mu), and the enricher reads live game state
+	// via *Game accessors that need the same lock — running it inline would
+	// deadlock. The history entry is updated in place once enrichment completes.
+	if ds.enricher != nil {
+		ds.enricherWG.Add(1)
+		go ds.enrichEntry(state.ID, seq)
+	}
+}
+
+func (ds *DataStore) enrichEntry(gameID string, seq int64) {
+	defer ds.enricherWG.Done()
+
+	snapshot, err := ds.GetGame(gameID)
+	if err != nil || snapshot == nil {
+		return
+	}
+	breakdowns := ds.enricher(snapshot)
+	if breakdowns == nil {
+		return
+	}
+
+	entryID := fmt.Sprintf("%s:%012d", gameID, seq)
+
+	htxn := ds.db.Txn(true)
+	defer htxn.Abort()
+
+	raw, err := htxn.First("game_history", "id", entryID)
+	if err != nil || raw == nil {
+		return
+	}
+	original, ok := raw.(*GameStateHistoryEntry)
+	if !ok {
+		return
+	}
+
+	updated := &GameStateHistoryEntry{
+		GameID:       original.GameID,
+		Sequence:     original.Sequence,
+		Timestamp:    original.Timestamp,
+		State:        original.State,
+		VPBreakdowns: breakdowns,
+	}
+	if err := htxn.Insert("game_history", updated); err != nil {
+		return
+	}
 	htxn.Commit()
 }
 

--- a/backend/internal/game/datastore/datastore.go
+++ b/backend/internal/game/datastore/datastore.go
@@ -11,11 +11,17 @@ import (
 	"terraforming-mars-backend/internal/game/shared"
 )
 
+// SnapshotEnricher computes per-player VP breakdowns for a snapshot, using the live
+// game state at the moment the snapshot is recorded. The map is stored on the history
+// entry so the history mapper doesn't need to reimplement scoring logic.
+type SnapshotEnricher func(state *GameState) map[string]shared.VPBreakdown
+
 // DataStore is the single source of truth for all game data.
 type DataStore struct {
 	db              *memdb.MemDB
 	historySeqMu    sync.Mutex
 	historySequence map[string]int64 // per-game sequence counter
+	enricher        SnapshotEnricher
 }
 
 func NewDataStore() (*DataStore, error) {
@@ -27,6 +33,12 @@ func NewDataStore() (*DataStore, error) {
 		db:              db,
 		historySequence: make(map[string]int64),
 	}, nil
+}
+
+// SetSnapshotEnricher registers a callback invoked for each history append.
+// Pass nil to disable enrichment.
+func (ds *DataStore) SetSnapshotEnricher(fn SnapshotEnricher) {
+	ds.enricher = fn
 }
 
 func (ds *DataStore) GetGame(gameID string) (*GameState, error) {
@@ -102,11 +114,17 @@ func (ds *DataStore) appendHistory(state *GameState) {
 	seq := ds.historySequence[state.ID]
 	ds.historySeqMu.Unlock()
 
+	var vpBreakdowns map[string]shared.VPBreakdown
+	if ds.enricher != nil {
+		vpBreakdowns = ds.enricher(state)
+	}
+
 	entry := &GameStateHistoryEntry{
-		GameID:    state.ID,
-		Sequence:  seq,
-		Timestamp: time.Now(),
-		State:     copied,
+		GameID:       state.ID,
+		Sequence:     seq,
+		Timestamp:    time.Now(),
+		State:        copied,
+		VPBreakdowns: vpBreakdowns,
 	}
 
 	htxn := ds.db.Txn(true)

--- a/backend/internal/game/datastore/game_state.go
+++ b/backend/internal/game/datastore/game_state.go
@@ -82,10 +82,11 @@ type GameState struct {
 
 // GameStateHistoryEntry stores a full GameState snapshot at a point in time.
 type GameStateHistoryEntry struct {
-	GameID    string
-	Sequence  int64
-	Timestamp time.Time
-	State     *GameState
+	GameID       string
+	Sequence     int64
+	Timestamp    time.Time
+	State        *GameState
+	VPBreakdowns map[string]shared.VPBreakdown
 }
 
 // PlayerState holds a single player's data.

--- a/backend/test/action/game/snapshot_vp_parity_test.go
+++ b/backend/test/action/game/snapshot_vp_parity_test.go
@@ -1,0 +1,67 @@
+package game_test
+
+import (
+	"context"
+	"testing"
+
+	gameaction "terraforming-mars-backend/internal/action/game"
+	"terraforming-mars-backend/internal/game/datastore"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/test/testutil"
+)
+
+// TestSnapshotEnricher_ParityWithFinalScoring verifies that the VP breakdown stored
+// on each history snapshot (via the enricher) matches what FinalScoringAction would
+// compute on the same game state. This is the core single-source-of-truth guarantee:
+// any future change to scoring logic flows to both code paths automatically.
+func TestSnapshotEnricher_ParityWithFinalScoring(t *testing.T) {
+	g, repo, cardRegistry, playerIDs := testutil.SetupMultiPlayerGame(t, 2)
+	ctx := context.Background()
+	awardRegistry := testutil.CreateTestAwardRegistry()
+	milestoneRegistry := testutil.CreateTestMilestoneRegistry()
+
+	repo.DataStore().SetSnapshotEnricher(func(state *datastore.GameState) map[string]shared.VPBreakdown {
+		live, err := repo.Get(ctx, state.ID)
+		if err != nil || live == nil {
+			return nil
+		}
+		return gameaction.ComputePlayerVPBreakdowns(live, cardRegistry, awardRegistry, milestoneRegistry)
+	})
+
+	p1, _ := g.GetPlayer(playerIDs[0])
+	p2, _ := g.GetPlayer(playerIDs[1])
+
+	p1.Resources().Set(shared.Resources{Heat: 30, Credits: 100})
+	p2.Resources().Set(shared.Resources{Heat: 5, Credits: 100})
+
+	if err := g.Awards().FundAward(ctx, "thermalist", playerIDs[0], 8); err != nil {
+		t.Fatalf("Fund Thermalist award: %v", err)
+	}
+
+	if err := g.SetGeneration(ctx, g.Generation()+1); err != nil {
+		t.Fatalf("Bump generation to trigger snapshot: %v", err)
+	}
+
+	expected := gameaction.ComputePlayerVPBreakdowns(g, cardRegistry, awardRegistry, milestoneRegistry)
+	testutil.AssertTrue(t, expected != nil, "ComputePlayerVPBreakdowns should produce a result")
+
+	history, err := repo.DataStore().GetGameHistory(g.ID())
+	testutil.AssertNoError(t, err, "GetGameHistory")
+	testutil.AssertTrue(t, len(history) > 0, "History should have at least one entry")
+
+	latest := history[len(history)-1]
+	testutil.AssertTrue(t, latest.VPBreakdowns != nil, "Latest snapshot should have VPBreakdowns populated by the enricher")
+
+	for _, pid := range playerIDs {
+		exp := expected[pid]
+		got, ok := latest.VPBreakdowns[pid]
+		testutil.AssertTrue(t, ok, "VPBreakdowns should contain entry for player "+pid)
+		testutil.AssertEqual(t, exp.TotalVP, got.TotalVP, "TotalVP parity for player "+pid)
+		testutil.AssertEqual(t, exp.AwardVP, got.AwardVP, "AwardVP parity for player "+pid)
+		testutil.AssertEqual(t, exp.TerraformRating, got.TerraformRating, "TerraformRating parity for player "+pid)
+	}
+
+	winnerVP := expected[playerIDs[0]].AwardVP
+	loserVP := expected[playerIDs[1]].AwardVP
+	testutil.AssertTrue(t, winnerVP > loserVP, "Player with more heat should outscore on Thermalist")
+}

--- a/backend/test/action/game/snapshot_vp_parity_test.go
+++ b/backend/test/action/game/snapshot_vp_parity_test.go
@@ -3,6 +3,7 @@ package game_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	gameaction "terraforming-mars-backend/internal/action/game"
 	"terraforming-mars-backend/internal/game/datastore"
@@ -45,6 +46,9 @@ func TestSnapshotEnricher_ParityWithFinalScoring(t *testing.T) {
 	expected := gameaction.ComputePlayerVPBreakdowns(g, cardRegistry, awardRegistry, milestoneRegistry)
 	testutil.AssertTrue(t, expected != nil, "ComputePlayerVPBreakdowns should produce a result")
 
+	// Enrichment runs asynchronously, so wait for the goroutine before reading.
+	repo.DataStore().WaitForPendingEnrichments()
+
 	history, err := repo.DataStore().GetGameHistory(g.ID())
 	testutil.AssertNoError(t, err, "GetGameHistory")
 	testutil.AssertTrue(t, len(history) > 0, "History should have at least one entry")
@@ -64,4 +68,41 @@ func TestSnapshotEnricher_ParityWithFinalScoring(t *testing.T) {
 	winnerVP := expected[playerIDs[0]].AwardVP
 	loserVP := expected[playerIDs[1]].AwardVP
 	testutil.AssertTrue(t, winnerVP > loserVP, "Player with more heat should outscore on Thermalist")
+}
+
+// TestSnapshotEnricher_NoDeadlockUnderGameLock asserts that the enricher does
+// not deadlock when invoked from inside a state mutation that holds the live
+// game's lock. AddPlayer holds g.mu.Lock() across an internal g.update() call;
+// if the enricher ran inline in appendHistory it would try to RLock the same
+// mutex via g.GetAllPlayers() and deadlock.
+func TestSnapshotEnricher_NoDeadlockUnderGameLock(t *testing.T) {
+	g, repo, cardRegistry, _ := testutil.SetupMultiPlayerGame(t, 2)
+	ctx := context.Background()
+	awardRegistry := testutil.CreateTestAwardRegistry()
+	milestoneRegistry := testutil.CreateTestMilestoneRegistry()
+
+	repo.DataStore().SetSnapshotEnricher(func(state *datastore.GameState) map[string]shared.VPBreakdown {
+		live, err := repo.Get(ctx, state.ID)
+		if err != nil || live == nil {
+			return nil
+		}
+		return gameaction.ComputePlayerVPBreakdowns(live, cardRegistry, awardRegistry, milestoneRegistry)
+	})
+
+	// AddNewPlayer holds g.mu.Lock() during its internal g.update() — the case
+	// that triggered the deadlock in production.
+	done := make(chan error, 1)
+	go func() {
+		_, err := g.AddNewPlayer(ctx, "p3", "Third Player")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		testutil.AssertNoError(t, err, "AddNewPlayer should not error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddNewPlayer deadlocked — the enricher likely ran inline and hit g.mu")
+	}
+
+	repo.DataStore().WaitForPendingEnrichments()
 }

--- a/backend/test/delivery/dto/mapper_game_history_test.go
+++ b/backend/test/delivery/dto/mapper_game_history_test.go
@@ -5,75 +5,52 @@ import (
 	"time"
 
 	"terraforming-mars-backend/internal/delivery/dto"
-	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/test/testutil"
 )
 
-func TestToGameHistoryEntryDtos_TotalVP(t *testing.T) {
+func TestToGameHistoryEntryDtos_TotalVP_FromBreakdown(t *testing.T) {
 	playerID := "player-1"
-	ownerID := playerID
-
-	tiles := []board.Tile{
-		{
-			Coordinates: shared.HexPosition{Q: 0, R: 0, S: 0},
-			Type:        shared.ResourceLandTile,
-			OccupiedBy:  &board.TileOccupant{Type: shared.ResourceCityTile},
-			OwnerID:     &ownerID,
-		},
-		{
-			Coordinates: shared.HexPosition{Q: 1, R: -1, S: 0},
-			Type:        shared.ResourceLandTile,
-			OccupiedBy:  &board.TileOccupant{Type: shared.ResourceGreeneryTile},
-			OwnerID:     &ownerID,
-		},
-		{
-			Coordinates: shared.HexPosition{Q: 0, R: 1, S: -1},
-			Type:        shared.ResourceLandTile,
-			OccupiedBy:  &board.TileOccupant{Type: shared.ResourceGreeneryTile},
-			OwnerID:     &ownerID,
-		},
-	}
 
 	entry := &datastore.GameStateHistoryEntry{
 		GameID:    "game-1",
 		Sequence:  1,
 		Timestamp: time.Now(),
 		State: &datastore.GameState{
-			Tiles: tiles,
 			Players: map[string]*datastore.PlayerState{
 				playerID: {
 					ID:              playerID,
 					Name:            "Test Player",
 					Color:           "red",
 					TerraformRating: 25,
-					VPGranters: []shared.VPGranter{
-						{CardID: "card-1", CardName: "Card One", ComputedValue: 3},
-						{CardID: "card-2", CardName: "Card Two", ComputedValue: 4},
-					},
 					Resources:       shared.Resources{},
 					ResourceStorage: map[string]int{},
 				},
 			},
-			ClaimedMilestones: []shared.ClaimedMilestone{
-				{Type: "terraformer", PlayerID: playerID},
+			ClaimedMilestones: []shared.ClaimedMilestone{},
+			FundedAwards:      []shared.FundedAward{},
+			Settings:          shared.GameSettings{},
+		},
+		VPBreakdowns: map[string]shared.VPBreakdown{
+			playerID: {
+				TerraformRating: 25,
+				CardVP:          7,
+				MilestoneVP:     5,
+				AwardVP:         5,
+				GreeneryVP:      2,
+				CityVP:          2,
+				TotalVP:         46,
 			},
-			FundedAwards: []shared.FundedAward{},
-			Settings:     shared.GameSettings{},
 		},
 	}
 
 	dtos := dto.ToGameHistoryEntryDtos([]*datastore.GameStateHistoryEntry{entry})
 	testutil.AssertEqual(t, 1, len(dtos), "Should have one entry")
-
-	player := dtos[0].Players[playerID]
-	// TR=25, cardVP=3+4=7, greeneryVP=2, cityVP=2 (city at 0,0,0 adjacent to 2 greeneries), milestoneVP=5
-	expectedVP := 25 + 7 + 2 + 2 + 5
-	testutil.AssertEqual(t, expectedVP, player.TotalVP, "TotalVP should include TR, card VP, greenery VP, city VP, and milestone VP")
+	testutil.AssertEqual(t, 46, dtos[0].Players[playerID].TotalVP, "TotalVP should come from VPBreakdowns")
 }
 
-func TestToGameHistoryEntryDtos_TotalVP_NoVPGranters(t *testing.T) {
+func TestToGameHistoryEntryDtos_TotalVP_NilBreakdownDegradesGracefully(t *testing.T) {
 	playerID := "player-1"
 
 	entry := &datastore.GameStateHistoryEntry{
@@ -81,7 +58,6 @@ func TestToGameHistoryEntryDtos_TotalVP_NoVPGranters(t *testing.T) {
 		Sequence:  1,
 		Timestamp: time.Now(),
 		State: &datastore.GameState{
-			Tiles: []board.Tile{},
 			Players: map[string]*datastore.PlayerState{
 				playerID: {
 					ID:              playerID,
@@ -96,50 +72,11 @@ func TestToGameHistoryEntryDtos_TotalVP_NoVPGranters(t *testing.T) {
 			FundedAwards:      []shared.FundedAward{},
 			Settings:          shared.GameSettings{},
 		},
+		// VPBreakdowns deliberately nil — represents legacy entries or tests
+		// where the snapshot enricher wasn't wired. Mapper should not panic
+		// and should report 0.
 	}
 
 	dtos := dto.ToGameHistoryEntryDtos([]*datastore.GameStateHistoryEntry{entry})
-	player := dtos[0].Players[playerID]
-	testutil.AssertEqual(t, 20, player.TotalVP, "TotalVP should equal TR when no other VP sources exist")
-}
-
-func TestToGameHistoryEntryDtos_TotalVP_WorldTreeCountsAsGreenery(t *testing.T) {
-	playerID := "player-1"
-	ownerID := playerID
-
-	tiles := []board.Tile{
-		{
-			Coordinates: shared.HexPosition{Q: 0, R: 0, S: 0},
-			Type:        shared.ResourceLandTile,
-			OccupiedBy:  &board.TileOccupant{Type: shared.ResourceWorldTreeTile},
-			OwnerID:     &ownerID,
-		},
-	}
-
-	entry := &datastore.GameStateHistoryEntry{
-		GameID:    "game-1",
-		Sequence:  1,
-		Timestamp: time.Now(),
-		State: &datastore.GameState{
-			Tiles: tiles,
-			Players: map[string]*datastore.PlayerState{
-				playerID: {
-					ID:              playerID,
-					Name:            "Test Player",
-					Color:           "green",
-					TerraformRating: 20,
-					Resources:       shared.Resources{},
-					ResourceStorage: map[string]int{},
-				},
-			},
-			ClaimedMilestones: []shared.ClaimedMilestone{},
-			FundedAwards:      []shared.FundedAward{},
-			Settings:          shared.GameSettings{},
-		},
-	}
-
-	dtos := dto.ToGameHistoryEntryDtos([]*datastore.GameStateHistoryEntry{entry})
-	player := dtos[0].Players[playerID]
-	// TR=20, greeneryVP=1 (world-tree counts as greenery)
-	testutil.AssertEqual(t, 21, player.TotalVP, "World-tree tile should count as greenery for VP")
+	testutil.AssertEqual(t, 0, dtos[0].Players[playerID].TotalVP, "TotalVP should be 0 when VPBreakdowns is nil")
 }

--- a/frontend/src/components/ui/endgame/GameGraphs.tsx
+++ b/frontend/src/components/ui/endgame/GameGraphs.tsx
@@ -12,9 +12,9 @@ import type { GameHistoryEntryDto } from "../../../types/generated/api-types";
 import { useHoverSound } from "../../../hooks/useHoverSound";
 
 type GraphMode =
+  | "score"
   | "terraforming"
   | "global-params"
-  | "vp"
   | "tr"
   | "greeneries"
   | "cities"
@@ -29,9 +29,9 @@ type GraphMode =
   | "resource-value";
 
 const GRAPH_MODE_LABELS: Record<GraphMode, string> = {
+  score: "Score",
   "global-params": "Global Parameters",
   terraforming: "Terraforming",
-  vp: "VP",
   tr: "TR",
   greeneries: "Greeneries",
   cities: "Cities",
@@ -87,6 +87,13 @@ const GLOBAL_PARAM_LINES: { key: string; color: string; label: string }[] = [
   { key: "venus", color: "#f59e0b", label: "Venus" },
 ];
 
+const GLOBAL_PARAM_RAW_FIELDS: Record<string, { rawKey: string; unit: string }> = {
+  Temperature: { rawKey: "temperatureRaw", unit: "°C" },
+  Oxygen: { rawKey: "oxygenRaw", unit: "%" },
+  Oceans: { rawKey: "oceansRaw", unit: "" },
+  Venus: { rawKey: "venusRaw", unit: "%" },
+};
+
 const TOOLTIP_STYLE: React.CSSProperties = {
   backgroundColor: "rgba(10,10,15,0.95)",
   border: "1px solid rgba(255,255,255,0.2)",
@@ -98,9 +105,10 @@ interface CustomTooltipProps {
   active?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: Array<{ name: string; value: number; color: string; payload?: any }>;
+  formatValue?: (entry: { name: string; value: number; payload?: unknown }) => string;
 }
 
-const CustomTooltip: FC<CustomTooltipProps> = ({ active, payload }) => {
+const CustomTooltip: FC<CustomTooltipProps> = ({ active, payload, formatValue }) => {
   if (!active || !payload?.length) {
     return null;
   }
@@ -122,12 +130,27 @@ const CustomTooltip: FC<CustomTooltipProps> = ({ active, payload }) => {
       {payload.map((entry, i) => (
         <div key={i} className="flex items-center gap-2 text-sm" style={{ minWidth: 100 }}>
           <span style={{ color: entry.color }}>{entry.name}</span>
-          <span className="ml-auto text-white tabular-nums">{entry.value}</span>
+          <span className="ml-auto text-white tabular-nums">
+            {formatValue ? formatValue(entry) : entry.value}
+          </span>
         </div>
       ))}
     </div>
   );
 };
+
+function formatGlobalParamValue(entry: { name: string; value: number; payload?: unknown }): string {
+  const meta = GLOBAL_PARAM_RAW_FIELDS[entry.name];
+  const pct = `${Math.round(entry.value)}%`;
+  if (!meta || !entry.payload || typeof entry.payload !== "object") {
+    return pct;
+  }
+  const raw = (entry.payload as Record<string, unknown>)[meta.rawKey];
+  if (typeof raw !== "number") {
+    return pct;
+  }
+  return `${pct} (${raw}${meta.unit})`;
+}
 
 const TICK_STYLE = { fill: "rgba(255,255,255,0.8)", fontSize: 13 };
 
@@ -197,7 +220,7 @@ function GraphModeDropdown({
 type XAxisMode = "action" | "time";
 
 const GameGraphs: FC<GameGraphsProps> = ({ entries, playerColors, playerNames }) => {
-  const [mode, setMode] = useState<GraphMode>("global-params");
+  const [mode, setMode] = useState<GraphMode>("score");
   const [xAxisMode, setXAxisMode] = useState<XAxisMode>("action");
   const hoverSound = useHoverSound();
 
@@ -334,10 +357,14 @@ const GameGraphs: FC<GameGraphsProps> = ({ entries, playerColors, playerNames })
         idx: i,
         generation: e.generation,
         offsetMs: addOffsetMs(e),
-        temperature: e.temperature,
-        oxygen: e.oxygen,
-        oceans: e.oceans,
-        venus: e.venus,
+        temperature: ((e.temperature + 30) / 38) * 100,
+        oxygen: (e.oxygen / 14) * 100,
+        oceans: (e.oceans / 9) * 100,
+        venus: (e.venus / 30) * 100,
+        temperatureRaw: e.temperature,
+        oxygenRaw: e.oxygen,
+        oceansRaw: e.oceans,
+        venusRaw: e.venus,
       })),
     [sampledEntries, startTime],
   );
@@ -345,7 +372,7 @@ const GameGraphs: FC<GameGraphsProps> = ({ entries, playerColors, playerNames })
   const multiPlayerData = useMemo(() => {
     const getValueFn = (m: GraphMode): ((e: GameHistoryEntryDto, pid: string) => number) => {
       switch (m) {
-        case "vp":
+        case "score":
           return (e, pid) => e.players[pid]?.totalVP ?? 0;
         case "tr":
           return (e, pid) => e.players[pid]?.terraformRating ?? 0;
@@ -487,8 +514,19 @@ const GameGraphs: FC<GameGraphsProps> = ({ entries, playerColors, playerNames })
                   domain={[0, sampledEntries.length - 1]}
                 />
               )}
-              <YAxis {...Y_AXIS_PROPS} />
-              <Tooltip content={<CustomTooltip />} isAnimationActive={false} />
+              {mode === "global-params" ? (
+                <YAxis {...Y_AXIS_PROPS} domain={[0, 100]} tickFormatter={(v: number) => `${v}%`} />
+              ) : (
+                <YAxis {...Y_AXIS_PROPS} />
+              )}
+              <Tooltip
+                content={
+                  <CustomTooltip
+                    formatValue={mode === "global-params" ? formatGlobalParamValue : undefined}
+                  />
+                }
+                isAnimationActive={false}
+              />
               {fixedLinesConfig.map(({ key, color, label }) => (
                 <Line
                   key={key}


### PR DESCRIPTION
### Score graph (default mode)

Replaces the old VP mode with **Score** — answers "if the game ended at this moment, what would each player score?". Includes Award VP, which the previous VP mode did not.

### Global Parameters as % completed

Each parameter (temperature, oxygen, oceans, venus) now plots as % of its own range, so all four lines share a single 0–100% y-axis. Tooltip shows e.g. \`47% (3°C)\` so you still see the underlying value.

### Single source of truth for VP

The user explicitly asked for **one** code path for the score formula so future VP rule changes don't need duplicate updates.

- New \`ComputePlayerVPBreakdowns\` helper in \`internal/action/game\` is the only place that knows how to assemble a VP breakdown — it delegates to the existing \`CalculatePlayerVP\` (the same function the end-game scoreboard already used).
- \`DataStore.SetSnapshotEnricher\` lets \`main.go\` register a per-snapshot callback that runs \`ComputePlayerVPBreakdowns\` against the live game state and stores the result on the history entry.
- \`mapper_game_history.go\` now just reads \`entry.VPBreakdowns[id].TotalVP\`. The four \`computeHistory*VP\` helpers are gone.
- \`FinalScoringAction\` uses the same helper, and \`PlayerScore.Breakdown\` is \`shared.VPBreakdown\` directly — the per-field conversion at the end of \`Execute\` is gone.

### Async enrichment (deadlock fix)

Many state mutations call \`ds.UpdateGame\` from inside a \`g.mu.Lock()\` critical section (e.g. \`AddPlayer\`). Running the enricher inline in \`appendHistory\` would try to read live game state via \`g.GetAllPlayers()\` — which RLocks the same mutex — and deadlock. The enricher now runs in a goroutine and updates the history entry in place once it completes. \`WaitForPendingEnrichments\` lets tests read history deterministically.

### Tests

- \`snapshot_vp_parity_test.go::TestSnapshotEnricher_ParityWithFinalScoring\` — asserts the latest history entry's \`VPBreakdowns\` exactly matches a fresh \`ComputePlayerVPBreakdowns\` call on the same game (covers TR, AwardVP, TotalVP).
- \`snapshot_vp_parity_test.go::TestSnapshotEnricher_NoDeadlockUnderGameLock\` — wires the enricher *before* game creation and exercises \`AddNewPlayer\` (which holds \`g.mu.Lock\` during its internal \`g.update\`); fails fast if the goroutine hangs. This is the regression test for the deadlock symptom.
- Existing mapper tests rewritten to test the new contract: VP comes from \`VPBreakdowns\` when populated; nil breakdowns degrade gracefully to \`0\`.