### PR TITLE
fix: allow Skip when no opponent has the targeted resource

### DIFF
--- a/backend/test/action/play_card/play_card_any_player_test.go
+++ b/backend/test/action/play_card/play_card_any_player_test.go
@@ -93,6 +93,92 @@ func TestPlayCardAction_AsteroidSoloMode_SkipsTargetPlayer(t *testing.T) {
 	testutil.AssertEqual(t, 2, resources.Titanium, "Player should have gained 2 titanium")
 }
 
+func TestPlayCardAction_AsteroidEmptyTargetID_SkipsAnyPlayer(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	cardRegistry := testutil.CreateTestCardRegistry()
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	asteroidID := testutil.CardID("Asteroid")
+	corpID := testutil.CardID("Tharsis Republic")
+
+	players := testGame.GetAllPlayers()
+	attacker := players[0]
+	target := players[1]
+	attacker.SetCorporationID(corpID)
+	target.SetCorporationID(corpID)
+
+	testutil.AssertNoError(t, testGame.UpdateStatus(ctx, shared.GameStatusActive), "update status")
+	testutil.AssertNoError(t, testGame.UpdatePhase(ctx, shared.GamePhaseAction), "update phase")
+	testutil.AssertNoError(t, testGame.SetCurrentTurn(ctx, attacker.ID(), 2), "set current turn")
+
+	attacker.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit: 100,
+		shared.ResourcePlant:  4,
+	})
+	attacker.Hand().AddCard(asteroidID)
+
+	target.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourcePlant: 5,
+	})
+
+	playCardAction := cardAction.NewPlayCardAction(repo, cardRegistry, nil, logger)
+	payment := cardAction.PaymentRequest{Credits: 14}
+	emptyTargetID := ""
+	err := playCardAction.Execute(ctx, testGame.ID(), attacker.ID(), asteroidID, payment, nil, nil, &emptyTargetID, nil)
+	testutil.AssertNoError(t, err, "Failed to play Asteroid with empty target ID")
+
+	// Empty target ID should skip the any-player effect; nobody loses plants
+	testutil.AssertEqual(t, 5, target.Resources().Get().Plants, "Target plants should be unchanged when target ID is empty")
+	testutil.AssertEqual(t, 4, attacker.Resources().Get().Plants, "Attacker plants should be unchanged when target ID is empty")
+
+	// Other outputs (e.g., +2 titanium) should still apply
+	testutil.AssertEqual(t, 2, attacker.Resources().Get().Titanium, "Attacker should have gained 2 titanium")
+}
+
+func TestPlayCardAction_HiredRaidersEmptyTargetID_SkipsSteal(t *testing.T) {
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	cardRegistry := testutil.CreateTestCardRegistry()
+	logger := testutil.TestLogger()
+	ctx := context.Background()
+
+	hiredRaidersID := testutil.CardID("Hired Raiders")
+	corpID := testutil.CardID("Tharsis Republic")
+
+	players := testGame.GetAllPlayers()
+	attacker := players[0]
+	target := players[1]
+	attacker.SetCorporationID(corpID)
+	target.SetCorporationID(corpID)
+
+	testutil.AssertNoError(t, testGame.UpdateStatus(ctx, shared.GameStatusActive), "update status")
+	testutil.AssertNoError(t, testGame.UpdatePhase(ctx, shared.GamePhaseAction), "update phase")
+	testutil.AssertNoError(t, testGame.SetCurrentTurn(ctx, attacker.ID(), 2), "set current turn")
+
+	attacker.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceCredit: 100,
+		shared.ResourceSteel:  2,
+	})
+	attacker.Hand().AddCard(hiredRaidersID)
+
+	target.Resources().Add(map[shared.ResourceType]int{
+		shared.ResourceSteel: 5,
+	})
+
+	playCardAction := cardAction.NewPlayCardAction(repo, cardRegistry, nil, logger)
+	payment := cardAction.PaymentRequest{Credits: 1}
+	choiceIndex := 0
+	emptyTargetID := ""
+	err := playCardAction.Execute(ctx, testGame.ID(), attacker.ID(), hiredRaidersID, payment, &choiceIndex, nil, &emptyTargetID, nil)
+	testutil.AssertNoError(t, err, "Failed to play Hired Raiders with empty target ID")
+
+	// Empty target ID should skip the steal effect on both sides
+	testutil.AssertEqual(t, 5, target.Resources().Get().Steel, "Target steel should be unchanged when target ID is empty")
+	testutil.AssertEqual(t, 2, attacker.Resources().Get().Steel, "Attacker should not gain steel when target ID is empty")
+}
+
 func TestPlayCardAction_AsteroidPartialRemoval(t *testing.T) {
 	broadcaster := testutil.NewMockBroadcaster()
 	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)

--- a/frontend/src/components/layout/main/GameInterface.tsx
+++ b/frontend/src/components/layout/main/GameInterface.tsx
@@ -1248,6 +1248,7 @@ export default function GameInterface() {
                 production: p.production,
               })),
             ]}
+            currentPlayerId={currentPlayer?.id}
             onPlayerSelect={flow.handleTargetPlayerSelect}
             onCancel={flow.handleTargetPlayerCancel}
             isVisible={showTargetPlayerSelection}
@@ -1277,6 +1278,7 @@ export default function GameInterface() {
                 production: p.production,
               })),
             ]}
+            currentPlayerId={currentPlayer?.id}
             onPlayerSelect={flow.handleActionTargetPlayerSelect}
             onCancel={flow.handleActionTargetPlayerCancel}
             isVisible={showActionTargetPlayerSelection}

--- a/frontend/src/components/ui/popover/TargetPlayerSelectionPopover.tsx
+++ b/frontend/src/components/ui/popover/TargetPlayerSelectionPopover.tsx
@@ -21,6 +21,7 @@ interface TargetPlayerSelectionPopoverProps {
   amount: number;
   isSteal?: boolean;
   players: TargetPlayer[];
+  currentPlayerId?: string;
   onPlayerSelect: (playerId: string) => void;
   onCancel: () => void;
   isVisible: boolean;
@@ -63,6 +64,7 @@ const TargetPlayerSelectionPopover: React.FC<TargetPlayerSelectionPopoverProps> 
   amount,
   isSteal,
   players,
+  currentPlayerId,
   onPlayerSelect,
   onCancel,
   isVisible,
@@ -74,9 +76,17 @@ const TargetPlayerSelectionPopover: React.FC<TargetPlayerSelectionPopoverProps> 
     (player) => getPlayerResourceAmount(player, resourceType) > 0,
   );
   const hasNoTargets = eligiblePlayers.length === 0;
+  const eligibleOthers = currentPlayerId
+    ? eligiblePlayers.filter((p) => p.id !== currentPlayerId)
+    : eligiblePlayers;
+  const onlySelfEligible = !hasNoTargets && eligibleOthers.length === 0;
   const canDismiss = !mandatory || hasNoTargets;
 
   const handleContinueAnyway = () => {
+    onPlayerSelect("");
+  };
+
+  const handleSkip = () => {
     onPlayerSelect("");
   };
 
@@ -159,9 +169,16 @@ const TargetPlayerSelectionPopover: React.FC<TargetPlayerSelectionPopoverProps> 
               </GameButton>
             </>
           ) : (
-            <GameButton buttonType="secondary" variant="info" size="sm" onClick={onCancel}>
-              Cancel
-            </GameButton>
+            <>
+              {onlySelfEligible && (
+                <GameButton buttonType="primary" variant="warn" size="sm" onClick={handleSkip}>
+                  Skip
+                </GameButton>
+              )}
+              <GameButton buttonType="secondary" variant="info" size="sm" onClick={onCancel}>
+                Cancel
+              </GameButton>
+            </>
           )}
         </GameFlowFooter>
       )}


### PR DESCRIPTION
## Summary
- When a card destroys/steals from any player (e.g. Asteroid, Sabotage, Hired Raiders, Mining Expedition, Birds) and no opponent has the targeted resource, the player can now **Skip** the destroy/steal step instead of being forced to target themselves or cancel the card.
- When at least one opponent has the resource, the player must still pick a target — existing behavior is preserved.
- Backend already handled empty \`targetPlayerID\` gracefully; this PR adds the missing UI affordance plus regression tests for the empty-target path.

## Behavior matrix
| Self eligible | Other(s) eligible | Buttons shown |
|--|--|--|
| any | yes | Cancel only (must target an opponent) |
| yes | no | **Skip** + Cancel (NEW) |
| no | no | Continue Anyway + Cancel (existing) |

## Test plan
- [x] \`go test ./...\` (backend) — all green, including two new tests:
  - \`TestPlayCardAction_AsteroidEmptyTargetID_SkipsAnyPlayer\` — 2-player, empty target → no plants destroyed, +titanium still applies.
  - \`TestPlayCardAction_HiredRaidersEmptyTargetID_SkipsSteal\` — 2-player, empty target → no steal on either side.
- [x] \`oxlint\` and \`tsc --noEmit\` clean.
- [x] Manual: 2-player game, opponent has 0 plants, you have plants → play **Mining Expedition** → popover shows self + **Skip** + Cancel; clicking Skip resolves the card with +2 steel and +1 oxygen, no plants lost.
- [x] Manual: 2-player game, opponent has plants → play Mining Expedition → popover shows eligible players, only **Cancel** (no Skip).
- [x] Manual: both players at 0 plants → existing **Continue Anyway** path still works.