### PR TITLE
feat: scale project funding with player count

### DIFF
--- a/backend/internal/action/projectfunding/fund_seat.go
+++ b/backend/internal/action/projectfunding/fund_seat.go
@@ -93,12 +93,14 @@ func (a *FundSeatAction) Execute(ctx context.Context, gameID string, playerID st
 		return fmt.Errorf("project definition not found: %w", err)
 	}
 
+	scaledSeats := pf.ScaledSeats(definition.Seats, len(g.GetAllPlayers()))
+
 	seatIndex := len(projectState.SeatOwners)
-	if seatIndex >= len(definition.Seats) {
+	if seatIndex >= len(scaledSeats) {
 		return fmt.Errorf("all seats are filled for project: %s", projectID)
 	}
 
-	seat := definition.Seats[seatIndex]
+	seat := scaledSeats[seatIndex]
 	cost := seat.Cost
 
 	if payment.Credits < 0 || payment.Steel < 0 || payment.Titanium < 0 {
@@ -190,7 +192,7 @@ func (a *FundSeatAction) Execute(ctx context.Context, gameID string, playerID st
 	a.ConsumePlayerAction(g, log)
 
 	// Check for completion
-	if len(projectState.SeatOwners) >= len(definition.Seats) {
+	if len(projectState.SeatOwners) >= len(scaledSeats) {
 		a.completeProject(ctx, g, projectState, definition, log)
 	}
 
@@ -205,6 +207,7 @@ func (a *FundSeatAction) completeProject(ctx context.Context, g *game.Game, stat
 	state.IsCompleted = true
 
 	allPlayers := g.GetAllPlayers()
+	scaledTiers := pf.ScaledRewardTiers(def.RewardTiers, len(allPlayers))
 
 	// Count seats per player
 	seatCounts := map[string]int{}
@@ -214,7 +217,7 @@ func (a *FundSeatAction) completeProject(ctx context.Context, g *game.Game, stat
 
 	// Apply tier rewards to each funder
 	for playerID, count := range seatCounts {
-		tier := pf.FindBestTier(def.RewardTiers, count)
+		tier := pf.FindBestTier(scaledTiers, count)
 		if tier == nil {
 			continue
 		}

--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -871,6 +871,8 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 		playerCredits = playerObj.Resources().Get().Credits
 	}
 
+	playerCount := len(g.GetAllPlayers())
+
 	dtos := make([]ProjectFundingDto, 0, len(states))
 	for _, state := range states {
 		def, err := registry.GetByID(state.DefinitionID)
@@ -878,9 +880,12 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 			continue
 		}
 
+		scaledSeats := pfDomain.ScaledSeats(def.Seats, playerCount)
+		scaledTiers := pfDomain.ScaledRewardTiers(def.RewardTiers, playerCount)
+
 		// Build seat DTOs
-		seats := make([]ProjectSeatDto, len(def.Seats))
-		for i, seatDef := range def.Seats {
+		seats := make([]ProjectSeatDto, len(scaledSeats))
+		for i, seatDef := range scaledSeats {
 			subs := make([]ProjectPaymentSubDto, len(seatDef.PaymentSubstitutes))
 			for j, sub := range seatDef.PaymentSubstitutes {
 				subs[j] = ProjectPaymentSubDto{
@@ -922,9 +927,9 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 		nextSeatIndex := len(state.SeatOwners)
 		nextSeatCost := 0
 		var nextSeatSubs []ProjectPaymentSubDto
-		if nextSeatIndex < len(def.Seats) {
-			nextSeatCost = def.Seats[nextSeatIndex].Cost
-			for _, sub := range def.Seats[nextSeatIndex].PaymentSubstitutes {
+		if nextSeatIndex < len(scaledSeats) {
+			nextSeatCost = scaledSeats[nextSeatIndex].Cost
+			for _, sub := range scaledSeats[nextSeatIndex].PaymentSubstitutes {
 				nextSeatSubs = append(nextSeatSubs, ProjectPaymentSubDto{
 					ResourceType:   sub.ResourceType,
 					ConversionRate: sub.ConversionRate,
@@ -944,7 +949,7 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 				Code:    StateErrorCode("project-completed"),
 				Message: "This project is already completed",
 			})
-		} else if nextSeatIndex >= len(def.Seats) {
+		} else if nextSeatIndex >= len(scaledSeats) {
 			canBuy = false
 			buyErrors = append(buyErrors, StateErrorDto{
 				Code:    StateErrorCode("all-seats-filled"),
@@ -968,7 +973,7 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 
 		var currentPlayerTier *ProjectRewardTierDto
 		if currentPlayerSeats > 0 {
-			tier := pfDomain.FindBestTier(def.RewardTiers, currentPlayerSeats)
+			tier := pfDomain.FindBestTier(scaledTiers, currentPlayerSeats)
 			if tier != nil {
 				rewards := make([]ColonyOutputDto, len(tier.Rewards))
 				for j, r := range tier.Rewards {
@@ -982,8 +987,8 @@ func toProjectFundingDtos(g *game.Game, registry pfRegistry.ProjectFundingRegist
 		}
 
 		// Reward tiers
-		rewardTiers := make([]ProjectRewardTierDto, len(def.RewardTiers))
-		for i, tier := range def.RewardTiers {
+		rewardTiers := make([]ProjectRewardTierDto, len(scaledTiers))
+		for i, tier := range scaledTiers {
 			rewards := make([]ColonyOutputDto, len(tier.Rewards))
 			for j, r := range tier.Rewards {
 				rewards[j] = ColonyOutputDto{Type: r.Type, Amount: r.Amount}

--- a/backend/internal/game/projectfunding/projectfunding.go
+++ b/backend/internal/game/projectfunding/projectfunding.go
@@ -69,3 +69,75 @@ type ProjectState struct {
 	SeatOwners   []string // PlayerIDs in purchase order (same player can appear multiple times)
 	IsCompleted  bool
 }
+
+// SeatCostBaselinePlayers is the player count for which JSON seat costs and seat counts are calibrated.
+const SeatCostBaselinePlayers = 4
+
+// ScaledSeatCost returns the seat cost adjusted for the number of players.
+// JSON costs are calibrated for SeatCostBaselinePlayers; this scales linearly from there.
+func ScaledSeatCost(baseCost, playerCount int) int {
+	if baseCost <= 0 {
+		return baseCost
+	}
+	scaled := baseCost * playerCount / SeatCostBaselinePlayers
+	if scaled < 1 {
+		return 1
+	}
+	return scaled
+}
+
+// ScaledSeatCount returns the seat count adjusted for the number of players.
+// JSON counts are calibrated for SeatCostBaselinePlayers; rounds to nearest, floored at 1.
+func ScaledSeatCount(baseCount, playerCount int) int {
+	if baseCount <= 0 {
+		return baseCount
+	}
+	n := (baseCount*playerCount + SeatCostBaselinePlayers/2) / SeatCostBaselinePlayers
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// ScaledSeats returns seat definitions scaled to the given player count.
+// Seat costs are scaled via ScaledSeatCost. The list is truncated when shrinking
+// and extended by repeating the final JSON entry when growing.
+func ScaledSeats(seats []SeatDefinition, playerCount int) []SeatDefinition {
+	if len(seats) == 0 {
+		return nil
+	}
+	n := ScaledSeatCount(len(seats), playerCount)
+	out := make([]SeatDefinition, n)
+	for i := 0; i < n; i++ {
+		idx := i
+		if idx >= len(seats) {
+			idx = len(seats) - 1
+		}
+		src := seats[idx]
+		out[i] = SeatDefinition{
+			Cost:               ScaledSeatCost(src.Cost, playerCount),
+			PaymentSubstitutes: src.PaymentSubstitutes,
+		}
+	}
+	return out
+}
+
+// ScaledRewardTiers returns reward tiers with seatsOwned thresholds scaled by player count.
+// Thresholds are rounded to nearest and floored at 1.
+func ScaledRewardTiers(tiers []RewardTier, playerCount int) []RewardTier {
+	if len(tiers) == 0 {
+		return nil
+	}
+	out := make([]RewardTier, len(tiers))
+	for i, t := range tiers {
+		scaled := (t.SeatsOwned*playerCount + SeatCostBaselinePlayers/2) / SeatCostBaselinePlayers
+		if scaled < 1 {
+			scaled = 1
+		}
+		out[i] = RewardTier{
+			SeatsOwned: scaled,
+			Rewards:    t.Rewards,
+		}
+	}
+	return out
+}

--- a/backend/test/action/projectfunding/fund_seat_test.go
+++ b/backend/test/action/projectfunding/fund_seat_test.go
@@ -235,9 +235,10 @@ func TestFundSeat_Completion_SetsIsCompleted(t *testing.T) {
 	testGame, repo, pfRegistry, player1, _ := setupProjectFundingGame(t)
 	ctx := context.Background()
 
-	// Fill all seats except the last one
 	def, _ := pfRegistry.GetByID("pf_orbital_station")
-	owners := make([]string, len(def.Seats)-1)
+	scaledSeats := pf.ScaledSeats(def.Seats, len(testGame.GetAllPlayers()))
+
+	owners := make([]string, len(scaledSeats)-1)
 	for i := range owners {
 		owners[i] = "other_player"
 	}
@@ -246,7 +247,7 @@ func TestFundSeat_Completion_SetsIsCompleted(t *testing.T) {
 	p1, _ := testGame.GetPlayer(player1)
 	testutil.SetPlayerCredits(ctx, p1, 500)
 
-	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
@@ -260,9 +261,10 @@ func TestFundSeat_Completion_AllPlayersGetCompletionEffect(t *testing.T) {
 	testGame, repo, pfRegistry, player1, player2 := setupProjectFundingGame(t)
 	ctx := context.Background()
 
-	// pf_orbital_station completion effect: card-draw (5 cards for each player)
 	def, _ := pfRegistry.GetByID("pf_orbital_station")
-	owners := make([]string, len(def.Seats)-1)
+	scaledSeats := pf.ScaledSeats(def.Seats, len(testGame.GetAllPlayers()))
+
+	owners := make([]string, len(scaledSeats)-1)
 	for i := range owners {
 		owners[i] = player1
 	}
@@ -273,7 +275,7 @@ func TestFundSeat_Completion_AllPlayersGetCompletionEffect(t *testing.T) {
 	testutil.SetPlayerCredits(ctx, p1, 500)
 
 	p2HandBefore := len(p2.Hand().Cards())
-	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
@@ -309,8 +311,9 @@ func TestFundSeat_Completion_TerraformingHub_TR(t *testing.T) {
 
 	// pf_terraforming_hub: completion gives +2 TR to all players
 	def, _ := pfRegistry.GetByID("pf_terraforming_hub")
-	// Alternate seat owners between player1 and player2
-	owners := make([]string, len(def.Seats)-1)
+	scaledSeats := pf.ScaledSeats(def.Seats, len(testGame.GetAllPlayers()))
+
+	owners := make([]string, len(scaledSeats)-1)
 	for i := range owners {
 		if i%2 == 0 {
 			owners[i] = player1
@@ -326,7 +329,7 @@ func TestFundSeat_Completion_TerraformingHub_TR(t *testing.T) {
 
 	p1TRBefore := p1.Resources().TerraformRating()
 	p2TRBefore := p2.Resources().TerraformRating()
-	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_terraforming_hub", pfAction.FundSeatPayment{Credits: lastSeatCost})
@@ -342,7 +345,9 @@ func TestFundSeat_Completion_ProductionChoice_SetForAllPlayers(t *testing.T) {
 
 	// pf_solar_forge: completion gives each player production choice
 	def, _ := pfRegistry.GetByID("pf_solar_forge")
-	owners := make([]string, len(def.Seats)-1)
+	scaledSeats := pf.ScaledSeats(def.Seats, len(testGame.GetAllPlayers()))
+
+	owners := make([]string, len(scaledSeats)-1)
 	for i := range owners {
 		owners[i] = player1
 	}
@@ -352,7 +357,7 @@ func TestFundSeat_Completion_ProductionChoice_SetForAllPlayers(t *testing.T) {
 	p2, _ := testGame.GetPlayer(player2)
 	testutil.SetPlayerCredits(ctx, p1, 500)
 
-	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_solar_forge", pfAction.FundSeatPayment{Credits: lastSeatCost})
@@ -373,7 +378,9 @@ func TestFundSeat_Completion_MassCardDraw(t *testing.T) {
 
 	// pf_orbital_station: completion deals 3 cards to each player
 	def, _ := pfRegistry.GetByID("pf_orbital_station")
-	owners := make([]string, len(def.Seats)-1)
+	scaledSeats := pf.ScaledSeats(def.Seats, len(testGame.GetAllPlayers()))
+
+	owners := make([]string, len(scaledSeats)-1)
 	for i := range owners {
 		owners[i] = player1
 	}
@@ -385,7 +392,7 @@ func TestFundSeat_Completion_MassCardDraw(t *testing.T) {
 
 	p1HandBefore := len(p1.Hand().Cards())
 	p2HandBefore := len(p2.Hand().Cards())
-	lastSeatCost := def.Seats[len(def.Seats)-1].Cost
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
 
 	action := newAction(repo, pfRegistry)
 	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
@@ -396,4 +403,153 @@ func TestFundSeat_Completion_MassCardDraw(t *testing.T) {
 
 	testutil.AssertEqual(t, p1HandBefore+3, p1HandAfter, "P1 should receive 3 cards")
 	testutil.AssertEqual(t, p2HandBefore+3, p2HandAfter, "P2 should receive 3 cards")
+}
+
+// --- Player-Count Scaling Tests ---
+
+func setupProjectFundingGameN(t *testing.T, numPlayers int) (*game.Game, game.GameRepository, pfLoader.ProjectFundingRegistry, []string) {
+	t.Helper()
+	testGame, repo, _, players := testutil.SetupMultiPlayerGame(t, numPlayers)
+
+	pfDefs, err := pfLoader.LoadProjectsFromJSON("../../../assets/terraforming_mars_project_funding.json")
+	if err != nil {
+		t.Fatalf("Failed to load project funding: %v", err)
+	}
+	pfRegistry := pfLoader.NewInMemoryProjectFundingRegistry(pfDefs)
+
+	settings := testGame.Settings()
+	settings.CardPacks = append(settings.CardPacks, shared.PackProjectFunding)
+	testGame.UpdateSettings(context.Background(), settings)
+
+	return testGame, repo, pfRegistry, players
+}
+
+func TestFundSeat_ScaledCost_TwoPlayers_DeductsScaledAmount(t *testing.T) {
+	testGame, repo, pfRegistry, players := setupProjectFundingGameN(t, 2)
+	ctx := context.Background()
+	player1 := players[0]
+
+	setupProjectState(testGame, "pf_orbital_station", nil)
+
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	scaledCost := pf.ScaledSeatCost(def.Seats[0].Cost, 2) // 6 * 2 / 4 = 3
+
+	p1, _ := testGame.GetPlayer(player1)
+	testutil.SetPlayerCredits(ctx, p1, 100)
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: scaledCost})
+	testutil.AssertNoError(t, err, "Paying exactly the scaled cost should succeed")
+	testutil.AssertEqual(t, 100-scaledCost, testutil.GetPlayerCredits(p1), "Should deduct only the scaled cost")
+}
+
+func TestFundSeat_ScaledCost_FivePlayers_RequiresMore(t *testing.T) {
+	testGame, repo, pfRegistry, players := setupProjectFundingGameN(t, 5)
+	ctx := context.Background()
+	player1 := players[0]
+
+	setupProjectState(testGame, "pf_orbital_station", nil)
+
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	baseCost := def.Seats[0].Cost                // 6
+	scaledCost := pf.ScaledSeatCost(baseCost, 5) // 6 * 5 / 4 = 7
+	testutil.AssertTrue(t, scaledCost > baseCost, "5-player scaled cost should exceed JSON base")
+
+	p1, _ := testGame.GetPlayer(player1)
+	testutil.SetPlayerCredits(ctx, p1, baseCost) // exactly the JSON base, not enough
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: scaledCost})
+	testutil.AssertError(t, err, "Player with only base-cost credits should fail in a 5-player game")
+
+	testutil.SetPlayerCredits(ctx, p1, scaledCost)
+	err = action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: scaledCost})
+	testutil.AssertNoError(t, err, "With scaled-cost credits the seat should be affordable")
+}
+
+func TestFundSeat_ScaledSeatCount_TwoPlayers_TruncatesProject(t *testing.T) {
+	testGame, repo, pfRegistry, players := setupProjectFundingGameN(t, 2)
+	ctx := context.Background()
+	player1 := players[0]
+
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	scaledCount := pf.ScaledSeatCount(len(def.Seats), 2) // 6 * 2 / 4 = 3
+	testutil.AssertTrue(t, scaledCount < len(def.Seats), "2-player game should have fewer seats than JSON")
+
+	owners := make([]string, scaledCount)
+	for i := range owners {
+		owners[i] = "other_player"
+	}
+	setupProjectState(testGame, "pf_orbital_station", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: 50})
+	testutil.AssertError(t, err, "Funding past the scaled seat count should fail with all-seats-filled")
+}
+
+func TestFundSeat_ScaledSeatCount_FivePlayers_ExtendsProject(t *testing.T) {
+	testGame, repo, pfRegistry, players := setupProjectFundingGameN(t, 5)
+	ctx := context.Background()
+	player1 := players[0]
+
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	scaledCount := pf.ScaledSeatCount(len(def.Seats), 5) // 6 * 5 / 4 = 8 (rounded)
+	testutil.AssertTrue(t, scaledCount > len(def.Seats), "5-player game should have more seats than JSON")
+
+	// Pre-fill exactly len(def.Seats) seats; the action should still succeed
+	// because ScaledSeats grows by repeating the last entry.
+	owners := make([]string, len(def.Seats))
+	for i := range owners {
+		owners[i] = "other_player"
+	}
+	setupProjectState(testGame, "pf_orbital_station", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: 50})
+	testutil.AssertNoError(t, err, "5-player game allows extra seats beyond JSON count")
+
+	state := testGame.GetProjectFundingState("pf_orbital_station")
+	testutil.AssertEqual(t, len(def.Seats)+1, len(state.SeatOwners), "Extra seat should be recorded")
+}
+
+func TestFundSeat_ScaledTiers_TwoPlayers_LowerThresholds(t *testing.T) {
+	testGame, repo, pfRegistry, players := setupProjectFundingGameN(t, 2)
+	ctx := context.Background()
+	player1 := players[0]
+
+	// pf_orbital_station tier-1 reward (baseline at 2 seats) gives 5 credits + 2 titanium.
+	// At 2 players the threshold scales to 1 seat owned, so a single-seat funder qualifies.
+	def, _ := pfRegistry.GetByID("pf_orbital_station")
+	scaledSeats := pf.ScaledSeats(def.Seats, 2)
+
+	owners := make([]string, len(scaledSeats)-1)
+	for i := range owners {
+		owners[i] = "other_player"
+	}
+	setupProjectState(testGame, "pf_orbital_station", owners)
+
+	p1, _ := testGame.GetPlayer(player1)
+	testutil.SetPlayerCredits(ctx, p1, 500)
+
+	creditsBefore := testutil.GetPlayerCredits(p1)
+	titaniumBefore := p1.Resources().Get().Titanium
+	lastSeatCost := scaledSeats[len(scaledSeats)-1].Cost
+
+	action := newAction(repo, pfRegistry)
+	err := action.Execute(ctx, testGame.ID(), player1, "pf_orbital_station", pfAction.FundSeatPayment{Credits: lastSeatCost})
+	testutil.AssertNoError(t, err, "Funding the last seat should succeed")
+
+	// Player1 owns 1 seat. With baseline tiers (min 2) they'd get nothing.
+	// With scaled tiers (threshold 1) they should get the first tier's rewards.
+	expectedCredits := creditsBefore - lastSeatCost + 5
+	testutil.AssertEqual(t, expectedCredits, testutil.GetPlayerCredits(p1),
+		"Single-seat funder should receive scaled tier-1 credit reward")
+	testutil.AssertEqual(t, titaniumBefore+2, p1.Resources().Get().Titanium,
+		"Single-seat funder should receive scaled tier-1 titanium reward")
 }

--- a/backend/test/projectfunding/scaled_cost_test.go
+++ b/backend/test/projectfunding/scaled_cost_test.go
@@ -1,0 +1,169 @@
+package projectfunding_test
+
+import (
+	"fmt"
+	"testing"
+
+	pf "terraforming-mars-backend/internal/game/projectfunding"
+	"terraforming-mars-backend/test/testutil"
+)
+
+func TestScaledSeatCost_Baseline(t *testing.T) {
+	for _, base := range []int{5, 6, 8, 10, 12, 15, 18, 21} {
+		got := pf.ScaledSeatCost(base, pf.SeatCostBaselinePlayers)
+		testutil.AssertEqual(t, base, got, fmt.Sprintf("baseline should preserve base cost %d", base))
+	}
+}
+
+func TestScaledSeatCost_Linear(t *testing.T) {
+	tests := []struct {
+		base, players, want int
+	}{
+		{18, 2, 9},
+		{18, 3, 13},
+		{18, 4, 18},
+		{18, 5, 22},
+		{10, 2, 5},
+		{10, 5, 12},
+		{5, 2, 2},
+		{5, 5, 6},
+	}
+	for _, tc := range tests {
+		got := pf.ScaledSeatCost(tc.base, tc.players)
+		testutil.AssertEqual(t, tc.want, got,
+			fmt.Sprintf("ScaledSeatCost(%d, %d)", tc.base, tc.players))
+	}
+}
+
+func TestScaledSeatCost_Floor(t *testing.T) {
+	testutil.AssertEqual(t, 1, pf.ScaledSeatCost(1, 1), "should floor at 1")
+	testutil.AssertEqual(t, 1, pf.ScaledSeatCost(3, 1), "3*1/4 would be 0; floored to 1")
+}
+
+func TestScaledSeatCost_NonPositive(t *testing.T) {
+	testutil.AssertEqual(t, 0, pf.ScaledSeatCost(0, 4), "zero base returns zero")
+	testutil.AssertEqual(t, -2, pf.ScaledSeatCost(-2, 4), "negative base returned unchanged")
+}
+
+func TestScaledSeatCount_Baseline(t *testing.T) {
+	for _, base := range []int{1, 5, 6, 7} {
+		got := pf.ScaledSeatCount(base, pf.SeatCostBaselinePlayers)
+		testutil.AssertEqual(t, base, got, fmt.Sprintf("baseline should preserve seat count %d", base))
+	}
+}
+
+func TestScaledSeatCount_RoundsToNearest(t *testing.T) {
+	tests := []struct {
+		base, players, want int
+	}{
+		// base=6 (Orbital Station)
+		{6, 1, 2}, // 6/4 = 1.5 -> 2
+		{6, 2, 3},
+		{6, 3, 5}, // 18/4 = 4.5 -> 5
+		{6, 5, 8}, // 30/4 = 7.5 -> 8
+		// base=5 (Solar Forge)
+		{5, 1, 1}, // 5/4 = 1.25 -> 1
+		{5, 2, 3}, // 10/4 = 2.5 -> 3
+		{5, 3, 4}, // 15/4 = 3.75 -> 4
+		{5, 5, 6},
+		// base=7 (Terraforming Hub)
+		{7, 2, 4}, // 14/4 = 3.5 -> 4
+		{7, 3, 5}, // 21/4 = 5.25 -> 5
+		{7, 5, 9}, // 35/4 = 8.75 -> 9
+	}
+	for _, tc := range tests {
+		got := pf.ScaledSeatCount(tc.base, tc.players)
+		testutil.AssertEqual(t, tc.want, got,
+			fmt.Sprintf("ScaledSeatCount(%d, %d)", tc.base, tc.players))
+	}
+}
+
+func TestScaledSeatCount_Floor(t *testing.T) {
+	testutil.AssertEqual(t, 1, pf.ScaledSeatCount(1, 1), "1*1/4 rounded would be 0; floored to 1")
+}
+
+func TestScaledSeats_Truncates(t *testing.T) {
+	seats := []pf.SeatDefinition{
+		{Cost: 6}, {Cost: 8}, {Cost: 10}, {Cost: 12}, {Cost: 15}, {Cost: 18},
+	}
+	got := pf.ScaledSeats(seats, 2) // 2 players -> 3 seats
+	testutil.AssertEqual(t, 3, len(got), "2-player game truncates to 3 seats")
+	testutil.AssertEqual(t, 3, got[0].Cost, "scaled cost of first seat")
+	testutil.AssertEqual(t, 4, got[1].Cost, "scaled cost of second seat")
+	testutil.AssertEqual(t, 5, got[2].Cost, "scaled cost of third seat")
+}
+
+func TestScaledSeats_RepeatsLastWhenGrowing(t *testing.T) {
+	seats := []pf.SeatDefinition{
+		{Cost: 6}, {Cost: 8}, {Cost: 10}, {Cost: 12}, {Cost: 15}, {Cost: 18},
+	}
+	got := pf.ScaledSeats(seats, 5) // 5 players -> 8 seats
+	testutil.AssertEqual(t, 8, len(got), "5-player game grows to 8 seats")
+	// First 6 seats reflect JSON costs scaled by 5/4.
+	testutil.AssertEqual(t, 7, got[0].Cost, "6*5/4")
+	testutil.AssertEqual(t, 22, got[5].Cost, "18*5/4")
+	// Extra seats repeat the final entry's scaled cost.
+	testutil.AssertEqual(t, 22, got[6].Cost, "extra seat reuses last scaled cost")
+	testutil.AssertEqual(t, 22, got[7].Cost, "extra seat reuses last scaled cost")
+}
+
+func TestScaledSeats_PreservesPaymentSubstitutes(t *testing.T) {
+	seats := []pf.SeatDefinition{
+		{Cost: 6, PaymentSubstitutes: []pf.PaymentSubstitute{{ResourceType: "titanium", ConversionRate: 3}}},
+		{Cost: 8, PaymentSubstitutes: []pf.PaymentSubstitute{{ResourceType: "titanium", ConversionRate: 3}}},
+	}
+	got := pf.ScaledSeats(seats, 5)
+	for i, s := range got {
+		testutil.AssertEqual(t, 1, len(s.PaymentSubstitutes),
+			fmt.Sprintf("seat %d preserves payment substitutes", i))
+		testutil.AssertEqual(t, 3, s.PaymentSubstitutes[0].ConversionRate,
+			fmt.Sprintf("seat %d conversion rate is unchanged", i))
+	}
+}
+
+func TestScaledSeats_EmptyInput(t *testing.T) {
+	got := pf.ScaledSeats(nil, 4)
+	testutil.AssertTrue(t, got == nil, "nil input returns nil")
+}
+
+func TestScaledRewardTiers_Baseline(t *testing.T) {
+	tiers := []pf.RewardTier{
+		{SeatsOwned: 2, Rewards: []pf.Output{{Type: "credit", Amount: 5}}},
+		{SeatsOwned: 4, Rewards: []pf.Output{{Type: "tr", Amount: 1}}},
+	}
+	got := pf.ScaledRewardTiers(tiers, pf.SeatCostBaselinePlayers)
+	testutil.AssertEqual(t, 2, got[0].SeatsOwned, "baseline preserves first threshold")
+	testutil.AssertEqual(t, 4, got[1].SeatsOwned, "baseline preserves second threshold")
+}
+
+func TestScaledRewardTiers_Scales(t *testing.T) {
+	tiers := []pf.RewardTier{
+		{SeatsOwned: 2}, {SeatsOwned: 4}, {SeatsOwned: 6},
+	}
+	tests := []struct {
+		players        int
+		wantThresholds []int
+	}{
+		{2, []int{1, 2, 3}},
+		{3, []int{2, 3, 5}}, // 6/4=1.5->2, 12/4=3, 18/4=4.5->5
+		{5, []int{3, 5, 8}}, // 10/4=2.5->3, 20/4=5, 30/4=7.5->8
+	}
+	for _, tc := range tests {
+		got := pf.ScaledRewardTiers(tiers, tc.players)
+		for i, want := range tc.wantThresholds {
+			testutil.AssertEqual(t, want, got[i].SeatsOwned,
+				fmt.Sprintf("players=%d tier %d threshold", tc.players, i))
+		}
+	}
+}
+
+func TestScaledRewardTiers_FloorsAtOne(t *testing.T) {
+	tiers := []pf.RewardTier{{SeatsOwned: 1}}
+	got := pf.ScaledRewardTiers(tiers, 1) // 1*1/4 rounded = 0 -> floor to 1
+	testutil.AssertEqual(t, 1, got[0].SeatsOwned, "threshold floored at 1")
+}
+
+func TestScaledRewardTiers_Empty(t *testing.T) {
+	got := pf.ScaledRewardTiers(nil, 4)
+	testutil.AssertTrue(t, got == nil, "nil input returns nil")
+}


### PR DESCRIPTION
## Summary
- Project funding seat costs, seat counts, and reward tier thresholds now scale linearly from a 4-player baseline (`base * playerCount / 4`, rounded for counts/tiers, floored at 1). JSON definitions remain authoritative and represent the 4-player baseline.
- New helpers `ScaledSeatCost`, `ScaledSeatCount`, `ScaledSeats`, `ScaledRewardTiers` in `backend/internal/game/projectfunding/projectfunding.go` are the single point of truth, consumed by the `FundSeatAction` and the `toProjectFundingDtos` DTO mapper.
- When player count drives seat count above the JSON definition, the final seat entry repeats; below, the list is truncated.

## Test plan
- [x] `go test ./test/...` — full backend suite green
- [x] New unit tests in `test/projectfunding/scaled_cost_test.go` cover all four helpers across 1–5 players, including floor and edge cases
- [x] Action tests cover 2-player exact-cost deduction, 5-player insufficient-credits at JSON base, project truncation in 2-player games, project extension past JSON count in 5-player games, and 2-player tier-threshold scaling
- [x] `make lint-frontend typecheck` clean
- [x] Manual: `make run`, create games at 2/3/4/5 players with the project-funding pack enabled, open the Project Funding popover and confirm displayed costs/seat counts/tiers match the formula
- [x] Manual: in a 2-player game, fund a seat and confirm credits deducted equal the scaled cost; repeat in a 5-player game
- [x] Manual: with insufficient credits in a 5-player game, confirm the error message reports the scaled cost