### PR TITLE
feat: add 10 Mars maps with lobby selection

### DIFF
--- a/backend/assets/terraforming_mars_maps.json
+++ b/backend/assets/terraforming_mars_maps.json
@@ -1,0 +1,862 @@
+[
+  {
+    "id": "tharsis",
+    "name": "Tharsis",
+    "description": "The original map with four volcanic sites and the Noctis City region.",
+    "rows": [
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean"}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}], "displayName": "Tharsis Tholus"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 1}], "displayName": "Ascraeus Mons"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}], "displayName": "Pavonis Mons"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "plant", "amount": 2}], "displayName": "Arsia Mons"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}], "tags": ["noctis-city"], "displayName": "Noctis City"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ]
+    ]
+  },
+  {
+    "id": "hellas",
+    "name": "Hellas",
+    "description": "The southern polar region around the great Hellas basin. Heat bonuses near the pole, plants along the equator.",
+    "rows": [
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 3}]},
+        {"type": "ocean"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "ocean-placement", "amount": 1}, {"type": "credit", "amount": -6}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land"}
+      ]
+    ]
+  },
+  {
+    "id": "elysium",
+    "name": "Elysium",
+    "description": "Western lowlands with wide ocean channels and four volcanic sites including Olympus Mons.",
+    "rows": [
+      [
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean"},
+        {"type": "ocean"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "titanium", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 3}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 3}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]}
+      ]
+    ]
+  },
+  {
+    "id": "arabia-terra",
+    "name": "Arabia Terra",
+    "description": "Cratered highlands with cove tiles serving as dual land/ocean spaces. Rich in data and science bonuses.",
+    "rows": [
+      [
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "microbe", "amount": 2}, {"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "data", "amount": 2}, {"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "cove", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}, {"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "cove", "bonuses": [{"type": "energy-production", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "science", "amount": 1}, {"type": "card-draw", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "cove", "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "cove", "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "cove", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}, {"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}]}
+      ]
+    ]
+  },
+  {
+    "id": "amazonis",
+    "name": "Amazonis Planitia",
+    "description": "Flat lava plains west of Olympus Mons with wild resource bonuses and a restricted central zone.",
+    "rows": [
+      [
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 3}]},
+        {"type": "land", "bonuses": [{"type": "microbe", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "animal", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "microbe", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 2}]},
+        {"type": "ocean"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "heat", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "animal", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "microbe", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "empty"},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "microbe", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "heat", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "animal", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]}
+      ]
+    ]
+  },
+  {
+    "id": "terra-cimmeria",
+    "name": "Terra Cimmeria",
+    "description": "Densely cratered southern highlands rich in steel and titanium, with four volcanic zones.",
+    "rows": [
+      [
+        {"type": "ocean"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 3}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "energy", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]}
+      ]
+    ]
+  },
+  {
+    "id": "vastitas-borealis",
+    "name": "Vastitas Borealis",
+    "description": "Northern polar lowlands of an ancient ocean. Frozen CO2 can raise temperature at a cost.",
+    "rows": [
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}, {"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}, {"type": "titanium", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}, {"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "temperature", "amount": 1}, {"type": "credit", "amount": -3}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}, {"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "ocean"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]}
+      ]
+    ]
+  },
+  {
+    "id": "utopia-planitia",
+    "name": "Utopia Planitia",
+    "description": "The largest impact crater in the Solar System. Mineral-rich soil provides plant and energy bonuses.",
+    "rows": [
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "energy", "amount": 2}, {"type": "card-draw", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 3}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 2}, {"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}, {"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "ocean"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "titanium", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 2}]},
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ]
+    ]
+  },
+  {
+    "id": "vastitas-borealis-nova",
+    "name": "Vastitas Borealis Nova",
+    "description": "Updated northern polar map with delegate bonuses and revised temperature mechanics.",
+    "rows": [
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "steel", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "credit", "amount": 1}]}
+      ],
+      [
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "temperature", "amount": 1}, {"type": "credit", "amount": -3}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}, {"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "land", "volcanic": true, "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "credit", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]}
+      ]
+    ]
+  },
+  {
+    "id": "hollandia",
+    "name": "Hollandia",
+    "description": "Tournament map with an Asteroid Deflection Zone that protects plants from destruction.",
+    "rows": [
+      [
+        {"type": "ocean", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "deflection-zone", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}]},
+        {"type": "deflection-zone"},
+        {"type": "deflection-zone"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "deflection-zone", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "deflection-zone"},
+        {"type": "deflection-zone", "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 3}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean"},
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "deflection-zone", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "deflection-zone"},
+        {"type": "deflection-zone", "bonuses": [{"type": "steel", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "deflection-zone"},
+        {"type": "deflection-zone", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "deflection-zone"}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "steel", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}, {"type": "steel", "amount": 1}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "ocean", "bonuses": [{"type": "titanium", "amount": 2}]}
+      ],
+      [
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 3}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "ocean"},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "heat", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "titanium", "amount": 1}, {"type": "plant", "amount": 1}]},
+        {"type": "ocean", "bonuses": [{"type": "plant", "amount": 1}]}
+      ],
+      [
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 2}]},
+        {"type": "land", "bonuses": [{"type": "plant", "amount": 2}]},
+        {"type": "land"},
+        {"type": "land"},
+        {"type": "land", "bonuses": [{"type": "card-draw", "amount": 1}]}
+      ]
+    ]
+  }
+]

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,12 +27,14 @@ import (
 	"terraforming-mars-backend/internal/awards"
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/colonies"
+	"terraforming-mars-backend/internal/delivery/dto"
 	httpHandler "terraforming-mars-backend/internal/delivery/http"
 	wsHandler "terraforming-mars-backend/internal/delivery/websocket"
 	"terraforming-mars-backend/internal/delivery/websocket/core"
 	"terraforming-mars-backend/internal/game"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/logger"
+	"terraforming-mars-backend/internal/maps"
 	httpmiddleware "terraforming-mars-backend/internal/middleware/http"
 	msLoader "terraforming-mars-backend/internal/milestones"
 	pfLoader "terraforming-mars-backend/internal/projectfunding"
@@ -147,6 +149,16 @@ func main() {
 	milestoneRegistry := msLoader.NewInMemoryMilestoneRegistry(milestoneData)
 	log.Debug("Milestone registry initialized", zap.Int("milestone_count", len(milestoneData)))
 
+	// ========== Initialize Map Registry ==========
+	mapPath := filepath.Join(wd, "assets", "terraforming_mars_maps.json")
+	log.Debug("Loading maps from", zap.String("path", mapPath))
+
+	mapRegistry, err := maps.LoadMapsFromJSON(mapPath)
+	if err != nil {
+		log.Fatal("Failed to load maps", zap.Error(err))
+	}
+	log.Debug("Map registry initialized", zap.Int("map_count", len(mapRegistry.ListMaps())))
+
 	// ========== Initialize Game Repository (Single Source of Truth) ==========
 	ds, err := datastore.NewDataStore()
 	if err != nil {
@@ -171,13 +183,41 @@ func main() {
 	log.Debug("WebSocket hub initialized")
 
 	// ========== Initialize Game State Broadcaster (Automatic Broadcasting) ==========
-	broadcaster := wsHandler.NewBroadcaster(gameRepo, stateRepo, hub, cardRegistry, colonyRegistry, pfRegistry, stdProjRegistry, awardRegistry, milestoneRegistry)
+	availableMaps := make([]dto.MapInfoDto, 0)
+	for _, m := range mapRegistry.ListMaps() {
+		mapDef, _ := mapRegistry.GetMap(m.ID)
+		tiles := maps.GenerateBoardFromMap(mapDef, false)
+		previewTiles := make([]dto.MapPreviewTile, 0)
+		for _, t := range tiles {
+			if t.Location != "mars" || string(t.Type) == "empty" {
+				continue
+			}
+			volcanic := false
+			for _, tag := range t.Tags {
+				if tag == "volcanic" {
+					volcanic = true
+					break
+				}
+			}
+			previewTiles = append(previewTiles, dto.MapPreviewTile{
+				Q:        t.Coordinates.Q,
+				R:        t.Coordinates.R,
+				S:        t.Coordinates.S,
+				Type:     string(t.Type),
+				Volcanic: volcanic,
+				Tags:     t.Tags,
+			})
+		}
+		availableMaps = append(availableMaps, dto.MapInfoDto{ID: m.ID, Name: m.Name, Description: mapDef.Description, Tiles: previewTiles})
+	}
+	broadcaster := wsHandler.NewBroadcaster(gameRepo, stateRepo, hub, cardRegistry, colonyRegistry, pfRegistry, stdProjRegistry, awardRegistry, milestoneRegistry, availableMaps)
 	log.Debug("Game state broadcaster initialized (provides automatic broadcasting for all games)")
 
 	// ========== Initialize Game Actions ==========
 
 	// Game lifecycle (6)
-	createGameAction := gameAction.NewCreateGameAction(gameRepo, cardRegistry, log)
+	createGameAction := gameAction.NewCreateGameAction(gameRepo, cardRegistry, mapRegistry, log)
+	updateGameMapAction := gameAction.NewUpdateGameMapAction(gameRepo, mapRegistry, log)
 	joinGameAction := gameAction.NewJoinGameAction(gameRepo, cardRegistry, log, colonyRegistry)
 	healthChecker := bot.NewHealthChecker(log)
 	addBotAction := gameAction.NewAddBotAction(gameRepo, cardRegistry, healthChecker, broadcaster, log, colonyRegistry)
@@ -292,6 +332,7 @@ func main() {
 		joinGameAction,
 		addBotAction,
 		selectDemoChoicesAction,
+		updateGameMapAction,
 		// Card actions
 		playCardAction,
 		useCardActionAction,

--- a/backend/internal/action/game/create_game.go
+++ b/backend/internal/action/game/create_game.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/google/uuid"
@@ -10,12 +11,14 @@ import (
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
 	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/internal/maps"
 )
 
 // CreateGameAction handles the business logic for creating new games
 type CreateGameAction struct {
 	gameRepo     game.GameRepository
 	cardRegistry cards.CardRegistry
+	mapRegistry  *maps.MapRegistry
 	logger       *zap.Logger
 }
 
@@ -23,11 +26,13 @@ type CreateGameAction struct {
 func NewCreateGameAction(
 	gameRepo game.GameRepository,
 	cardRegistry cards.CardRegistry,
+	mapRegistry *maps.MapRegistry,
 	logger *zap.Logger,
 ) *CreateGameAction {
 	return &CreateGameAction{
 		gameRepo:     gameRepo,
 		cardRegistry: cardRegistry,
+		mapRegistry:  mapRegistry,
 		logger:       logger,
 	}
 }
@@ -50,6 +55,9 @@ func (a *CreateGameAction) Execute(
 	if settings.MaxPlayers == 0 {
 		settings.MaxPlayers = game.DefaultMaxPlayers
 	}
+	if settings.MapID == "" {
+		settings.MapID = maps.DefaultMapID()
+	}
 	if len(settings.CardPacks) == 0 {
 		settings.CardPacks = shared.DefaultCardPacks()
 	}
@@ -57,11 +65,15 @@ func (a *CreateGameAction) Execute(
 		settings.CardPacks = append(settings.CardPacks, shared.PackVenus)
 	}
 
-	// 3. Create game entity
-	// Note: hostPlayerID is empty initially, will be set when first player joins
-	// Board is automatically created by NewGame
-	// EventBus is created per-game for synchronous event handling
-	newGame := game.NewGame(a.gameRepo.DataStore(), gameID, "", settings)
+	// 3. Generate board tiles from selected map
+	mapDef, ok := a.mapRegistry.GetMap(settings.MapID)
+	if !ok {
+		return nil, fmt.Errorf("unknown map: %s", settings.MapID)
+	}
+	initialTiles := maps.GenerateBoardFromMap(mapDef, settings.VenusNextEnabled)
+
+	// 4. Create game entity
+	newGame := game.NewGame(a.gameRepo.DataStore(), gameID, "", settings, initialTiles)
 
 	// 4. Initialize deck with cards from selected packs
 	projectCardIDs, corpIDs, preludeIDs := cards.GetCardIDsByPacks(a.cardRegistry, settings.CardPacks)

--- a/backend/internal/action/game/update_game_map.go
+++ b/backend/internal/action/game/update_game_map.go
@@ -1,0 +1,69 @@
+package game
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/internal/maps"
+)
+
+// UpdateGameMapAction handles changing the map during lobby phase
+type UpdateGameMapAction struct {
+	gameRepo    game.GameRepository
+	mapRegistry *maps.MapRegistry
+	logger      *zap.Logger
+}
+
+// NewUpdateGameMapAction creates a new update game map action
+func NewUpdateGameMapAction(
+	gameRepo game.GameRepository,
+	mapRegistry *maps.MapRegistry,
+	logger *zap.Logger,
+) *UpdateGameMapAction {
+	return &UpdateGameMapAction{
+		gameRepo:    gameRepo,
+		mapRegistry: mapRegistry,
+		logger:      logger,
+	}
+}
+
+// Execute changes the map for a game in lobby phase
+func (a *UpdateGameMapAction) Execute(ctx context.Context, gameID string, playerID string, mapID string) error {
+	log := a.logger.With(
+		zap.String("game_id", gameID),
+		zap.String("player_id", playerID),
+		zap.String("map_id", mapID),
+	)
+
+	g, err := a.gameRepo.Get(ctx, gameID)
+	if err != nil {
+		return fmt.Errorf("game not found: %w", err)
+	}
+
+	if g.Status() != shared.GameStatusLobby {
+		return fmt.Errorf("map can only be changed during lobby phase")
+	}
+
+	if g.HostPlayerID() != playerID {
+		return fmt.Errorf("only the host can change the map")
+	}
+
+	mapDef, ok := a.mapRegistry.GetMap(mapID)
+	if !ok {
+		return fmt.Errorf("unknown map: %s", mapID)
+	}
+
+	settings := g.Settings()
+	settings.MapID = mapID
+	g.UpdateSettings(ctx, settings)
+
+	initialTiles := maps.GenerateBoardFromMap(mapDef, settings.VenusNextEnabled)
+	g.ReplaceBoard(ctx, initialTiles)
+
+	log.Debug("Game map updated", zap.String("map_name", mapDef.Name))
+	return nil
+}

--- a/backend/internal/action/state_calculator.go
+++ b/backend/internal/action/state_calculator.go
@@ -667,6 +667,22 @@ func isBasicPlayerResource(rt shared.ResourceType) bool {
 	return false
 }
 
+// CanAffordResourceDeduction returns nil if the player has enough of resourceType
+// to absorb a negative amount. Returns nil unconditionally for positive amounts
+// or non-basic resource types. Used to gate any action whose bonus/output would
+// push a basic resource below zero.
+func CanAffordResourceDeduction(p *player.Player, resourceType shared.ResourceType, amount int) error {
+	if amount >= 0 || !isBasicPlayerResource(resourceType) {
+		return nil
+	}
+	available := p.Resources().Get().GetAmount(resourceType)
+	required := -amount
+	if available < required {
+		return fmt.Errorf("not enough %s: have %d, need %d", resourceType, available, required)
+	}
+	return nil
+}
+
 // validateNegativeResourceOutputsForCard checks all auto-trigger behaviors on a card
 // for negative resource outputs (e.g., "spend 5 heat" modeled as heat: -5).
 func validateNegativeResourceOutputsForCard(
@@ -692,21 +708,15 @@ func validateNegativeResourceOutputs(
 	p *player.Player,
 ) []player.StateError {
 	var errors []player.StateError
-	resources := p.Resources().Get()
 
 	for _, outputBC := range behavior.Outputs {
-		if shared.IsVariableAmount(outputBC) || outputBC.GetAmount() >= 0 {
+		if shared.IsVariableAmount(outputBC) {
 			continue
 		}
 		if outputBC.GetTarget() != "" && outputBC.GetTarget() != "self-player" {
 			continue
 		}
-		if !isBasicPlayerResource(outputBC.GetResourceType()) {
-			continue
-		}
-		available := resources.GetAmount(outputBC.GetResourceType())
-		required := -outputBC.GetAmount()
-		if available < required {
+		if err := CanAffordResourceDeduction(p, outputBC.GetResourceType(), outputBC.GetAmount()); err != nil {
 			errors = append(errors, player.StateError{
 				Code:     player.ErrorCodeInsufficientResources,
 				Category: player.ErrorCategoryInput,

--- a/backend/internal/action/tile/select_tile.go
+++ b/backend/internal/action/tile/select_tile.go
@@ -292,6 +292,15 @@ func (a *SelectTileAction) Execute(ctx context.Context, gameID string, playerID 
 		return result, nil
 	}
 
+	if preTile, err := g.Board().GetTile(*coords); err == nil {
+		for _, bonus := range preTile.Bonuses {
+			if err := baseaction.CanAffordResourceDeduction(p, bonus.Type, bonus.Amount); err != nil {
+				log.Debug("Tile placement blocked by unaffordable bonus", zap.Error(err))
+				return nil, fmt.Errorf("cannot place tile here: %w", err)
+			}
+		}
+	}
+
 	occupantTags := []string{}
 	if pendingTileSelection.SourceCardID != "" {
 		occupantTags = append(occupantTags, "source:"+pendingTileSelection.SourceCardID)
@@ -310,6 +319,8 @@ func (a *SelectTileAction) Execute(ctx context.Context, gameID string, playerID 
 		zap.String("tile_type", tileType),
 		zap.String("position", selectedHex))
 
+	var queuedTilePlacements []string
+
 	placedTile, err := g.Board().GetTile(*coords)
 	if err != nil {
 		log.Warn("Failed to get placed tile for bonus check", zap.Error(err))
@@ -320,13 +331,65 @@ func (a *SelectTileAction) Execute(ctx context.Context, gameID string, playerID 
 
 		for _, bonus := range placedTile.Bonuses {
 			switch bonus.Type {
-			case shared.ResourceSteel, shared.ResourceTitanium, shared.ResourcePlant, shared.ResourceCredit:
+			case shared.ResourceSteel, shared.ResourceTitanium, shared.ResourcePlant,
+				shared.ResourceCredit, shared.ResourceEnergy, shared.ResourceHeat:
 				p.Resources().Add(map[shared.ResourceType]int{
 					bonus.Type: bonus.Amount,
 				})
 				log.Debug("Awarded resource bonus",
 					zap.String("resource", string(bonus.Type)),
 					zap.Int("amount", bonus.Amount))
+
+				resourceBonuses[string(bonus.Type)] = bonus.Amount
+
+			case shared.ResourceEnergyProduction, shared.ResourceHeatProduction,
+				shared.ResourcePlantProduction, shared.ResourceSteelProduction,
+				shared.ResourceTitaniumProduction, shared.ResourceCreditProduction:
+				p.Resources().AddProduction(map[shared.ResourceType]int{
+					bonus.Type: bonus.Amount,
+				})
+				log.Debug("Awarded production bonus",
+					zap.String("production", string(bonus.Type)),
+					zap.Int("amount", bonus.Amount))
+
+				resourceBonuses[string(bonus.Type)] = bonus.Amount
+
+			case shared.ResourceTemperature:
+				stepsRaised, err := g.GlobalParameters().IncreaseTemperature(ctx, bonus.Amount, playerID)
+				if err != nil {
+					log.Warn("Failed to raise temperature for bonus", zap.Error(err))
+					continue
+				}
+				if stepsRaised > 0 {
+					p.Resources().UpdateTerraformRating(stepsRaised)
+				}
+				log.Debug("Awarded temperature bonus",
+					zap.Int("requested_steps", bonus.Amount),
+					zap.Int("actual_steps", stepsRaised))
+
+				resourceBonuses[string(bonus.Type)] = stepsRaised
+
+			case shared.ResourceOxygen:
+				stepsRaised, err := g.GlobalParameters().IncreaseOxygen(ctx, bonus.Amount, playerID)
+				if err != nil {
+					log.Warn("Failed to raise oxygen for bonus", zap.Error(err))
+					continue
+				}
+				if stepsRaised > 0 {
+					p.Resources().UpdateTerraformRating(stepsRaised)
+				}
+				log.Debug("Awarded oxygen bonus",
+					zap.Int("requested_steps", bonus.Amount),
+					zap.Int("actual_steps", stepsRaised))
+
+				resourceBonuses[string(bonus.Type)] = stepsRaised
+
+			case shared.ResourceOceanPlacement:
+				for i := 0; i < bonus.Amount; i++ {
+					queuedTilePlacements = append(queuedTilePlacements, "ocean")
+				}
+				log.Debug("Queued ocean placement bonus",
+					zap.Int("count", bonus.Amount))
 
 				resourceBonuses[string(bonus.Type)] = bonus.Amount
 
@@ -356,7 +419,7 @@ func (a *SelectTileAction) Execute(ctx context.Context, gameID string, playerID 
 					zap.Strings("card_ids", cardIDs))
 
 			default:
-				log.Warn(" Unhandled tile bonus type",
+				log.Warn("Unhandled tile bonus type",
 					zap.String("type", string(bonus.Type)),
 					zap.Int("amount", bonus.Amount))
 			}
@@ -465,6 +528,12 @@ func (a *SelectTileAction) Execute(ctx context.Context, gameID string, playerID 
 
 	if err := g.SetPendingTileSelection(ctx, playerID, nil); err != nil {
 		return nil, fmt.Errorf("failed to clear pending tile selection: %w", err)
+	}
+
+	if len(queuedTilePlacements) > 0 {
+		if err := g.AppendToPendingTileSelectionQueue(ctx, playerID, queuedTilePlacements, "tile-bonus", "", nil); err != nil {
+			return nil, fmt.Errorf("failed to queue tile placement from bonus: %w", err)
+		}
 	}
 
 	if err := g.ProcessNextTile(ctx, playerID); err != nil {

--- a/backend/internal/delivery/dto/game_dto.go
+++ b/backend/internal/delivery/dto/game_dto.go
@@ -526,18 +526,38 @@ type ProductionPhaseOtherPlayerDto struct {
 
 // GameSettingsDto contains configurable game parameters
 type GameSettingsDto struct {
-	MaxPlayers            int      `json:"maxPlayers"`
-	VenusNextEnabled      bool     `json:"venusNextEnabled"`
-	DevelopmentMode       bool     `json:"developmentMode"`
-	DemoGame              bool     `json:"demoGame"`
-	CardPacks             []string `json:"cardPacks,omitempty"`
-	HasClaudeAPIKey       bool     `json:"hasClaudeApiKey"`
-	ClaudeModel           string   `json:"claudeModel,omitempty"`
-	AvailablePlayerColors []string `json:"availablePlayerColors"`
-	Temperature           *int     `json:"temperature,omitempty"`
-	Oxygen                *int     `json:"oxygen,omitempty"`
-	Oceans                *int     `json:"oceans,omitempty"`
-	Generation            *int     `json:"generation,omitempty"`
+	MaxPlayers            int          `json:"maxPlayers"`
+	MapID                 string       `json:"mapId"`
+	VenusNextEnabled      bool         `json:"venusNextEnabled"`
+	DevelopmentMode       bool         `json:"developmentMode"`
+	DemoGame              bool         `json:"demoGame"`
+	CardPacks             []string     `json:"cardPacks,omitempty"`
+	HasClaudeAPIKey       bool         `json:"hasClaudeApiKey"`
+	ClaudeModel           string       `json:"claudeModel,omitempty"`
+	AvailablePlayerColors []string     `json:"availablePlayerColors"`
+	AvailableMaps         []MapInfoDto `json:"availableMaps"`
+	Temperature           *int         `json:"temperature,omitempty"`
+	Oxygen                *int         `json:"oxygen,omitempty"`
+	Oceans                *int         `json:"oceans,omitempty"`
+	Generation            *int         `json:"generation,omitempty"`
+}
+
+// MapInfoDto contains basic map info for the frontend
+type MapInfoDto struct {
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Tiles       []MapPreviewTile `json:"tiles"`
+}
+
+// MapPreviewTile contains minimal tile data for map preview
+type MapPreviewTile struct {
+	Q        int      `json:"q"`
+	R        int      `json:"r"`
+	S        int      `json:"s"`
+	Type     string   `json:"type"`
+	Volcanic bool     `json:"volcanic,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
 }
 
 // PendingDemoChoicesDto contains a player's demo lobby card selections

--- a/backend/internal/delivery/dto/mapper_game.go
+++ b/backend/internal/delivery/dto/mapper_game.go
@@ -32,6 +32,7 @@ type Registries struct {
 	StandardProjectRegistry standardprojects.StandardProjectRegistry
 	AwardRegistry           awards.AwardRegistry
 	MilestoneRegistry       milestones.MilestoneRegistry
+	AvailableMaps           []MapInfoDto
 }
 
 func ToGameDto(g *game.Game, cardRegistry cards.CardRegistry, playerID string, colonyRegistry ...colonies.ColonyRegistry) GameDto {
@@ -76,6 +77,7 @@ func ToGameDtoFull(g *game.Game, cardRegistry cards.CardRegistry, playerID strin
 	settings := g.Settings()
 	settingsDto := GameSettingsDto{
 		MaxPlayers:            settings.MaxPlayers,
+		MapID:                 settings.MapID,
 		VenusNextEnabled:      settings.VenusNextEnabled,
 		DevelopmentMode:       settings.DevelopmentMode,
 		DemoGame:              settings.DemoGame,
@@ -83,6 +85,7 @@ func ToGameDtoFull(g *game.Game, cardRegistry cards.CardRegistry, playerID strin
 		HasClaudeAPIKey:       settings.ClaudeAPIKey != "",
 		ClaudeModel:           settings.ClaudeModel,
 		AvailablePlayerColors: shared.PlayerColors,
+		AvailableMaps:         registries.AvailableMaps,
 		Temperature:           settings.Temperature,
 		Oxygen:                settings.Oxygen,
 		Oceans:                settings.Oceans,

--- a/backend/internal/delivery/dto/message_types.go
+++ b/backend/internal/delivery/dto/message_types.go
@@ -71,6 +71,7 @@ const (
 	MessageTypeEndGame        MessageType = "end-game"
 	MessageTypeGameEnded      MessageType = "game-ended"
 
+	MessageTypeUpdateGameMap         MessageType = "update-game-map"
 	MessageTypeSetPlayerColor        MessageType = "set-player-color"
 	MessageTypeSpectatorConnect      MessageType = "spectator-connect"
 	MessageTypeSpectatorConnected    MessageType = "spectator-connected"

--- a/backend/internal/delivery/websocket/broadcaster.go
+++ b/backend/internal/delivery/websocket/broadcaster.go
@@ -35,6 +35,7 @@ type Broadcaster struct {
 	standardProjectRegistry standardprojects.StandardProjectRegistry
 	awardRegistry           awards.AwardRegistry
 	milestoneRegistry       milestones.MilestoneRegistry
+	availableMaps           []dto.MapInfoDto
 	botNotifier             BotNotifier
 	logger                  *zap.Logger
 	lastBroadcastedSeq      map[string]int64 // gameID -> last broadcasted log sequence
@@ -52,6 +53,7 @@ func NewBroadcaster(
 	stdProjReg standardprojects.StandardProjectRegistry,
 	awardReg awards.AwardRegistry,
 	msReg milestones.MilestoneRegistry,
+	availableMaps []dto.MapInfoDto,
 ) *Broadcaster {
 	broadcaster := &Broadcaster{
 		gameRepo:                gameRepo,
@@ -63,6 +65,7 @@ func NewBroadcaster(
 		standardProjectRegistry: stdProjReg,
 		awardRegistry:           awardReg,
 		milestoneRegistry:       msReg,
+		availableMaps:           availableMaps,
 		logger:                  logger.Get(),
 		lastBroadcastedSeq:      make(map[string]int64),
 	}
@@ -207,6 +210,7 @@ func (b *Broadcaster) sendToPlayer(ctx context.Context, game *game.Game, playerI
 		StandardProjectRegistry: b.standardProjectRegistry,
 		AwardRegistry:           b.awardRegistry,
 		MilestoneRegistry:       b.milestoneRegistry,
+		AvailableMaps:           b.availableMaps,
 	})
 
 	message := dto.WebSocketMessage{

--- a/backend/internal/delivery/websocket/handler/game/update_game_map.go
+++ b/backend/internal/delivery/websocket/handler/game/update_game_map.go
@@ -1,0 +1,75 @@
+package game
+
+import (
+	"context"
+
+	gameaction "terraforming-mars-backend/internal/action/game"
+	"terraforming-mars-backend/internal/delivery/dto"
+	"terraforming-mars-backend/internal/delivery/websocket/core"
+	"terraforming-mars-backend/internal/logger"
+
+	"go.uber.org/zap"
+)
+
+// UpdateGameMapHandler handles update game map requests
+type UpdateGameMapHandler struct {
+	updateGameMapAction *gameaction.UpdateGameMapAction
+	broadcaster         Broadcaster
+	logger              *zap.Logger
+}
+
+// NewUpdateGameMapHandler creates a new handler
+func NewUpdateGameMapHandler(action *gameaction.UpdateGameMapAction, broadcaster Broadcaster) *UpdateGameMapHandler {
+	return &UpdateGameMapHandler{
+		updateGameMapAction: action,
+		broadcaster:         broadcaster,
+		logger:              logger.Get(),
+	}
+}
+
+// HandleMessage implements the MessageHandler interface
+func (h *UpdateGameMapHandler) HandleMessage(ctx context.Context, connection *core.Connection, message dto.WebSocketMessage) {
+	log := h.logger.With(
+		zap.String("connection_id", connection.ID),
+		zap.String("message_type", string(message.Type)),
+	)
+
+	payloadMap, ok := message.Payload.(map[string]interface{})
+	if !ok {
+		h.sendError(connection, "Invalid payload")
+		return
+	}
+
+	mapID, ok := payloadMap["mapId"].(string)
+	if !ok || mapID == "" {
+		h.sendError(connection, "Missing mapId")
+		return
+	}
+
+	gameID := connection.GameID
+	playerID := connection.PlayerID
+
+	if gameID == "" || playerID == "" {
+		h.sendError(connection, "Not connected to a game")
+		return
+	}
+
+	err := h.updateGameMapAction.Execute(ctx, gameID, playerID, mapID)
+	if err != nil {
+		log.Debug("Failed to update game map", zap.Error(err))
+		h.sendError(connection, err.Error())
+		return
+	}
+
+	h.broadcaster.BroadcastGameState(gameID, nil)
+	log.Debug("Game map updated and broadcast")
+}
+
+func (h *UpdateGameMapHandler) sendError(connection *core.Connection, errorMessage string) {
+	connection.Send <- dto.WebSocketMessage{
+		Type: dto.MessageTypeError,
+		Payload: map[string]interface{}{
+			"error": errorMessage,
+		},
+	}
+}

--- a/backend/internal/delivery/websocket/registry.go
+++ b/backend/internal/delivery/websocket/registry.go
@@ -42,6 +42,7 @@ func RegisterHandlers(
 	joinGameAction *gameAction.JoinGameAction,
 	addBotAction *gameAction.AddBotAction,
 	selectDemoChoicesAction *gameAction.SelectDemoChoicesAction,
+	updateGameMapAction *gameAction.UpdateGameMapAction,
 	playCardAction *cardAction.PlayCardAction,
 	useCardActionAction *cardAction.UseCardActionAction,
 	executeStandardProjectAction *stdprojAction.ExecuteStandardProjectAction,
@@ -102,6 +103,9 @@ func RegisterHandlers(
 
 	selectDemoChoicesHandler := game.NewSelectDemoChoicesHandler(selectDemoChoicesAction, broadcaster)
 	hub.RegisterHandler(dto.MessageTypeActionSelectDemoChoices, selectDemoChoicesHandler)
+
+	updateGameMapHandler := game.NewUpdateGameMapHandler(updateGameMapAction, broadcaster)
+	hub.RegisterHandler(dto.MessageTypeUpdateGameMap, updateGameMapHandler)
 
 	playCardHandler := card.NewPlayCardHandler(playCardAction, broadcaster)
 	hub.RegisterHandler(dto.MessageTypeActionPlayCard, playCardHandler)

--- a/backend/internal/game/game.go
+++ b/backend/internal/game/game.go
@@ -200,13 +200,14 @@ func (g *Game) read(fn func(s *datastore.GameState)) {
 	}
 }
 
-// NewGame creates a new game with the given settings.
+// NewGame creates a new game with the given settings and initial board tiles.
 // The DataStore is used as the single point of entry for all state reads/writes.
 func NewGame(
 	ds *datastore.DataStore,
 	id string,
 	hostPlayerID string,
 	settings shared.GameSettings,
+	initialTiles []board.Tile,
 ) *Game {
 	now := time.Now()
 
@@ -276,7 +277,7 @@ func NewGame(
 		ds:               ds,
 		id:               id,
 		globalParameters: global_parameters.NewGlobalParameters(ds, id, eventBus),
-		board:            board.NewBoardWithTiles(&state.Tiles, id, board.GenerateMarsBoard(settings.VenusNextEnabled), eventBus),
+		board:            board.NewBoardWithTiles(&state.Tiles, id, initialTiles, eventBus),
 		colonies:         colonies.NewColonies(ds, id, eventBus),
 		players:          make(map[string]*player.Player),
 		eventBus:         eventBus,
@@ -323,6 +324,16 @@ func (g *Game) Settings() shared.GameSettings {
 func (g *Game) UpdateSettings(ctx context.Context, settings shared.GameSettings) {
 	g.update(func(s *datastore.GameState) {
 		s.Settings = settings
+		s.UpdatedAt = time.Now()
+	})
+}
+
+// ReplaceBoard replaces the board tiles (used when changing maps in lobby)
+func (g *Game) ReplaceBoard(ctx context.Context, newTiles []board.Tile) {
+	g.update(func(s *datastore.GameState) {
+		tilesCopy := make([]board.Tile, len(newTiles))
+		copy(tilesCopy, newTiles)
+		s.Tiles = tilesCopy
 		s.UpdatedAt = time.Now()
 	})
 }

--- a/backend/internal/game/shared/game_types.go
+++ b/backend/internal/game/shared/game_types.go
@@ -32,6 +32,7 @@ const (
 // GameSettings contains configurable game parameters
 type GameSettings struct {
 	MaxPlayers         int
+	MapID              string
 	Temperature        *int
 	Oxygen             *int
 	Oceans             *int

--- a/backend/internal/maps/loader.go
+++ b/backend/internal/maps/loader.go
@@ -1,0 +1,234 @@
+package maps
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+
+	"terraforming-mars-backend/internal/game/board"
+	"terraforming-mars-backend/internal/game/shared"
+)
+
+// MapDefinition represents a map loaded from JSON
+type MapDefinition struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Rows        [][]TileDefJSON `json:"rows"`
+}
+
+// TileDefJSON represents a single tile in the JSON map definition
+type TileDefJSON struct {
+	Type        string          `json:"type"`
+	Bonuses     []TileBonusJSON `json:"bonuses,omitempty"`
+	Volcanic    bool            `json:"volcanic,omitempty"`
+	Tags        []string        `json:"tags,omitempty"`
+	DisplayName string          `json:"displayName,omitempty"`
+}
+
+// TileBonusJSON represents a tile bonus in JSON
+type TileBonusJSON struct {
+	Type   string `json:"type"`
+	Amount int    `json:"amount"`
+}
+
+// MapRegistry holds all loaded map definitions
+type MapRegistry struct {
+	maps    map[string]*MapDefinition
+	mapList []*MapDefinition
+}
+
+// NewMapRegistry creates a new empty map registry
+func NewMapRegistry() *MapRegistry {
+	return &MapRegistry{
+		maps:    make(map[string]*MapDefinition),
+		mapList: make([]*MapDefinition, 0),
+	}
+}
+
+// LoadMapsFromJSON loads map definitions from a JSON file
+func LoadMapsFromJSON(filepath string) (*MapRegistry, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read maps file: %w", err)
+	}
+
+	var defs []MapDefinition
+	if err := json.Unmarshal(data, &defs); err != nil {
+		return nil, fmt.Errorf("failed to parse maps JSON: %w", err)
+	}
+
+	if len(defs) == 0 {
+		return nil, fmt.Errorf("no maps found in file: %s", filepath)
+	}
+
+	registry := NewMapRegistry()
+	for i := range defs {
+		registry.maps[defs[i].ID] = &defs[i]
+		registry.mapList = append(registry.mapList, &defs[i])
+	}
+
+	return registry, nil
+}
+
+// RegisterMap adds a map definition to the registry
+func (r *MapRegistry) RegisterMap(def *MapDefinition) {
+	r.maps[def.ID] = def
+	r.mapList = append(r.mapList, def)
+}
+
+// GetMap returns a map definition by ID
+func (r *MapRegistry) GetMap(id string) (*MapDefinition, bool) {
+	m, ok := r.maps[id]
+	return m, ok
+}
+
+// ListMaps returns all available map IDs and names
+func (r *MapRegistry) ListMaps() []MapInfo {
+	infos := make([]MapInfo, len(r.mapList))
+	for i, m := range r.mapList {
+		infos[i] = MapInfo{ID: m.ID, Name: m.Name, Description: m.Description}
+	}
+	return infos
+}
+
+// MapInfo contains basic map identification
+type MapInfo struct {
+	ID          string
+	Name        string
+	Description string
+}
+
+// DefaultMapID returns the default map ID
+func DefaultMapID() string {
+	return "tharsis"
+}
+
+// GenerateBoardFromMap converts a map definition to board tiles with cube coordinates.
+// The row pattern is [5,6,7,8,9,8,7,6,5] matching the standard Mars hex grid.
+func GenerateBoardFromMap(mapDef *MapDefinition, includeVenus bool) []board.Tile {
+	tiles := []board.Tile{}
+	radius := 4
+
+	for rowIdx, row := range mapDef.Rows {
+		r := rowIdx - radius
+		qMin := max(-radius, -r-radius)
+
+		for colIdx, tileDef := range row {
+			q := qMin + colIdx
+			s := -q - r
+			pos := shared.HexPosition{Q: q, R: r, S: s}
+
+			tileType := mapTileType(tileDef.Type)
+			bonuses := mapBonuses(tileDef.Bonuses)
+
+			tags := tileDef.Tags
+			if tags == nil {
+				tags = []string{}
+			}
+			if tileDef.Volcanic {
+				tags = appendIfMissing(tags, board.BoardTagVolcanic)
+			}
+
+			var displayName *string
+			if tileDef.DisplayName != "" {
+				name := tileDef.DisplayName
+				displayName = &name
+			}
+
+			tiles = append(tiles, board.Tile{
+				Coordinates: pos,
+				Type:        tileType,
+				Location:    board.TileLocationMars,
+				Tags:        tags,
+				DisplayName: displayName,
+				Bonuses:     bonuses,
+			})
+		}
+	}
+
+	// Celestial body tiles (always added)
+	celestialTiles := []struct {
+		Pos         shared.HexPosition
+		Tags        []string
+		DisplayName string
+		Location    board.TileLocation
+	}{
+		{shared.HexPosition{Q: 500, R: 0, S: -500}, []string{board.BoardTagPhobosSpaceHaven}, "Phobos Space Haven", board.TileLocationPhobos},
+		{shared.HexPosition{Q: 400, R: 0, S: -400}, []string{board.BoardTagDawnCity}, "Dawn City", board.TileLocationMercury},
+		{shared.HexPosition{Q: 200, R: 0, S: -200}, []string{board.BoardTagGanymedeColony}, "Ganymede Colony", board.TileLocationGanymede},
+		{shared.HexPosition{Q: 300, R: 0, S: -300}, []string{board.BoardTagLunaMetropolis}, "Luna Metropolis", board.TileLocationLuna},
+	}
+	for _, ct := range celestialTiles {
+		displayName := ct.DisplayName
+		tiles = append(tiles, board.Tile{
+			Coordinates: ct.Pos,
+			Type:        shared.ResourceLandTile,
+			Location:    ct.Location,
+			Tags:        ct.Tags,
+			DisplayName: &displayName,
+		})
+	}
+
+	if !includeVenus {
+		return tiles
+	}
+
+	venusTiles := []struct {
+		Pos         shared.HexPosition
+		Tags        []string
+		DisplayName string
+	}{
+		{shared.HexPosition{Q: 100, R: 0, S: -100}, []string{board.BoardTagMaxwellBase}, "Maxwell Base"},
+		{shared.HexPosition{Q: 102, R: 0, S: -102}, []string{board.BoardTagStratopolis}, "Stratopolis"},
+	}
+	for _, vt := range venusTiles {
+		displayName := vt.DisplayName
+		tiles = append(tiles, board.Tile{
+			Coordinates: vt.Pos,
+			Type:        shared.ResourceLandTile,
+			Location:    board.TileLocationVenus,
+			Tags:        vt.Tags,
+			DisplayName: &displayName,
+		})
+	}
+
+	return tiles
+}
+
+func mapTileType(t string) shared.ResourceType {
+	switch t {
+	case "ocean":
+		return shared.ResourceOceanSpace
+	case "cove":
+		return shared.ResourceOceanSpace
+	case "empty":
+		return shared.ResourceType("empty")
+	case "deflection-zone":
+		return shared.ResourceLandTile
+	default:
+		return shared.ResourceLandTile
+	}
+}
+
+func mapBonuses(bonuses []TileBonusJSON) []board.TileBonus {
+	if len(bonuses) == 0 {
+		return nil
+	}
+	result := make([]board.TileBonus, len(bonuses))
+	for i, b := range bonuses {
+		result[i] = board.TileBonus{
+			Type:   shared.ResourceType(b.Type),
+			Amount: b.Amount,
+		}
+	}
+	return result
+}
+
+func appendIfMissing(slice []string, val string) []string {
+	if slices.Contains(slice, val) {
+		return slice
+	}
+	return append(slice, val)
+}

--- a/backend/test/action/card_effects/player_card_integration_test.go
+++ b/backend/test/action/card_effects/player_card_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"terraforming-mars-backend/internal/action"
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	gamecards "terraforming-mars-backend/internal/game/cards"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/player"
@@ -27,7 +28,7 @@ func TestPlayerCard_EventDrivenStateUpdate(t *testing.T) {
 	// Create test game
 	settings := shared.GameSettings{MaxPlayers: 5, DevelopmentMode: true}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Add player
 	ctx := context.Background()
@@ -126,7 +127,7 @@ func TestPlayerCard_ResourceChangeEventUpdate(t *testing.T) {
 	// Create test game
 	settings := shared.GameSettings{MaxPlayers: 5, DevelopmentMode: true}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Add player
 	ctx := context.Background()
@@ -216,7 +217,7 @@ func TestPlayerCard_PhaseChangeEventUpdate(t *testing.T) {
 	// Create test game
 	settings := shared.GameSettings{MaxPlayers: 5, DevelopmentMode: true}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Add player
 	ctx := context.Background()
@@ -306,7 +307,7 @@ func TestPlayerCard_CleanupPreventsMemoryLeak(t *testing.T) {
 	// Create test game
 	settings := shared.GameSettings{MaxPlayers: 5, DevelopmentMode: true}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Add player
 	ctx := context.Background()
@@ -402,7 +403,7 @@ func TestPlayerCard_MultipleCardsIndependentState(t *testing.T) {
 	// Create test game
 	settings := shared.GameSettings{MaxPlayers: 5, DevelopmentMode: true}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Add player
 	ctx := context.Background()

--- a/backend/test/action/core/generational_events_test.go
+++ b/backend/test/action/core/generational_events_test.go
@@ -8,6 +8,7 @@ import (
 	"terraforming-mars-backend/internal/action"
 	"terraforming-mars-backend/internal/events"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/player"
 	"terraforming-mars-backend/internal/game/shared"
@@ -25,7 +26,7 @@ func setupGenerationalEventsTestEnvironment(t *testing.T) (*game.Game, *player.P
 		DevelopmentMode: true,
 	}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	ctx := context.Background()
 	p, err := g.AddNewPlayer(ctx, "player1", "Test Player")

--- a/backend/test/action/core/state_calculator_test.go
+++ b/backend/test/action/core/state_calculator_test.go
@@ -7,6 +7,7 @@ import (
 	"terraforming-mars-backend/internal/action"
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	gamecards "terraforming-mars-backend/internal/game/cards"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/player"
@@ -28,7 +29,7 @@ func setupTestEnvironment(t *testing.T) (*game.Game, *player.Player, cards.CardR
 		DevelopmentMode: true,
 	}
 	ds, _ := datastore.NewDataStore()
-	g := game.NewGame(ds, "test-game", "player1", settings)
+	g := game.NewGame(ds, "test-game", "player1", settings, board.GenerateMarsBoard(false))
 
 	// Create and add test player
 	ctx := context.Background()

--- a/backend/test/action/game_lifecycle/create_game_test.go
+++ b/backend/test/action/game_lifecycle/create_game_test.go
@@ -16,7 +16,7 @@ func TestCreateGameAction_Success(t *testing.T) {
 	cardRegistry := testutil.CreateTestCardRegistry()
 	logger := testutil.TestLogger()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 
 	// Execute
 	settings := shared.GameSettings{
@@ -44,7 +44,7 @@ func TestCreateGameAction_DefaultSettings(t *testing.T) {
 	cardRegistry := testutil.CreateTestCardRegistry()
 	logger := testutil.TestLogger()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 
 	// Execute with empty settings
 	settings := shared.GameSettings{}
@@ -62,7 +62,7 @@ func TestCreateGameAction_DeckInitialization(t *testing.T) {
 	cardRegistry := testutil.CreateTestCardRegistry()
 	logger := testutil.TestLogger()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 
 	// Execute
 	settings := shared.GameSettings{
@@ -88,7 +88,7 @@ func TestCreateGameAction_MultipleCardPacks(t *testing.T) {
 	cardRegistry := testutil.CreateTestCardRegistry()
 	logger := testutil.TestLogger()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 
 	// Execute with multiple packs
 	settings := shared.GameSettings{
@@ -109,7 +109,7 @@ func TestCreateGameAction_BoardInitialization(t *testing.T) {
 	cardRegistry := testutil.CreateTestCardRegistry()
 	logger := testutil.TestLogger()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 
 	// Execute
 	settings := shared.GameSettings{

--- a/backend/test/action/game_lifecycle/join_game_test.go
+++ b/backend/test/action/game_lifecycle/join_game_test.go
@@ -6,6 +6,7 @@ import (
 
 	gameAction "terraforming-mars-backend/internal/action/game"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/test/testutil"
@@ -123,7 +124,7 @@ func TestJoinGameAction_MaxPlayersReached(t *testing.T) {
 	}
 
 	ds, _ := datastore.NewDataStore()
-	testGame := game.NewGame(ds, "test-game", "", settings)
+	testGame := game.NewGame(ds, "test-game", "", settings, board.GenerateMarsBoard(false))
 	testutil.AssertNoError(t, repo.Create(context.Background(), testGame), "create game in repo")
 
 	// Add 2 players

--- a/backend/test/action/tiles/tile_placement_bonus_test.go
+++ b/backend/test/action/tiles/tile_placement_bonus_test.go
@@ -272,6 +272,242 @@ func TestSelectTileAction_OceanAdjacencyBonus_OceanTileGetsBonus(t *testing.T) {
 		"Ocean tile placement should receive +2 M€ for one adjacent ocean tile")
 }
 
+// TestSelectTileAction_MultipleBonusesOnTile verifies that placing on a tile
+// with multiple bonuses (e.g. temperature + credit, as on the Vastitas Borealis
+// Nova north-pole tile) awards each bonus independently: the temperature step
+// raises the global parameter and grants 1 TR, and the credit bonus is added
+// to the player's resources.
+func TestSelectTileAction_MultipleBonusesOnTile(t *testing.T) {
+	ctx := context.Background()
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+	stateRepo := game.NewInMemoryGameStateRepository()
+
+	testutil.StartTestGame(t, testGame)
+
+	playerID := testGame.TurnOrder()[0]
+	p, _ := testGame.GetPlayer(playerID)
+	testutil.SetPlayerCredits(ctx, p, 100)
+
+	// Find an unoccupied land tile and overwrite its bonuses to [temperature 1, credit 4]
+	tiles := testGame.Board().Tiles()
+	var targetIdx = -1
+	for i, tile := range tiles {
+		if tile.OccupiedBy == nil && tile.Type == shared.ResourceLandTile {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx == -1 {
+		t.Fatal("No unoccupied land tile found")
+	}
+	tiles[targetIdx].Bonuses = []board.TileBonus{
+		{Type: shared.ResourceTemperature, Amount: 1},
+		{Type: shared.ResourceCredit, Amount: 4},
+	}
+	targetCoords := tiles[targetIdx].Coordinates
+	testutil.AssertNoError(t, testGame.Board().SetTiles(ctx, tiles), "set tiles")
+
+	initialCredits := p.Resources().Get().Credits
+	initialTR := p.Resources().TerraformRating()
+	initialTemp := testGame.GlobalParameters().Temperature()
+
+	hexStr := formatHexCoords(targetCoords)
+	pendingSelection := &shared.PendingTileSelection{
+		TileType:       "city",
+		AvailableHexes: []string{hexStr},
+		Source:         "test",
+	}
+	testutil.AssertNoError(t, testGame.SetPendingTileSelection(ctx, playerID, pendingSelection), "set pending tile selection")
+
+	selectTileAction := tileAction.NewSelectTileAction(repo, cardRegistry, stateRepo, logger)
+	_, err := selectTileAction.Execute(ctx, testGame.ID(), playerID, hexStr)
+	testutil.AssertNoError(t, err, "Failed to place tile")
+
+	testutil.AssertEqual(t, initialTemp+2, testGame.GlobalParameters().Temperature(),
+		"Temperature should rise by 2°C (1 step)")
+	testutil.AssertEqual(t, initialTR+1, p.Resources().TerraformRating(),
+		"Player should gain 1 TR for the temperature step")
+	testutil.AssertEqual(t, initialCredits+4, p.Resources().Get().Credits,
+		"Player should gain 4 credits from the credit bonus")
+
+	placedTile, err := testGame.Board().GetTile(targetCoords)
+	testutil.AssertNoError(t, err, "Failed to get placed tile")
+	testutil.AssertEqual(t, 0, len(placedTile.Bonuses),
+		"Bonuses should be cleared after placement")
+}
+
+// TestSelectTileAction_OceanPlacementBonus verifies that placing on a tile
+// with an `ocean-placement` bonus queues a follow-up ocean placement: after the
+// initial tile is placed, the player has a new pending tile selection of type
+// "ocean" so they can pick where to place it.
+func TestSelectTileAction_OceanPlacementBonus(t *testing.T) {
+	ctx := context.Background()
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+	stateRepo := game.NewInMemoryGameStateRepository()
+
+	testutil.StartTestGame(t, testGame)
+
+	playerID := testGame.TurnOrder()[0]
+	p, _ := testGame.GetPlayer(playerID)
+	testutil.SetPlayerCredits(ctx, p, 100)
+
+	tiles := testGame.Board().Tiles()
+	var targetIdx = -1
+	for i, tile := range tiles {
+		if tile.OccupiedBy == nil && tile.Type == shared.ResourceLandTile {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx == -1 {
+		t.Fatal("No unoccupied land tile found")
+	}
+	tiles[targetIdx].Bonuses = []board.TileBonus{
+		{Type: shared.ResourceOceanPlacement, Amount: 1},
+	}
+	targetCoords := tiles[targetIdx].Coordinates
+	testutil.AssertNoError(t, testGame.Board().SetTiles(ctx, tiles), "set tiles")
+
+	hexStr := formatHexCoords(targetCoords)
+	pendingSelection := &shared.PendingTileSelection{
+		TileType:       "city",
+		AvailableHexes: []string{hexStr},
+		Source:         "test",
+	}
+	testutil.AssertNoError(t, testGame.SetPendingTileSelection(ctx, playerID, pendingSelection), "set pending tile selection")
+
+	selectTileAction := tileAction.NewSelectTileAction(repo, cardRegistry, stateRepo, logger)
+	_, err := selectTileAction.Execute(ctx, testGame.ID(), playerID, hexStr)
+	testutil.AssertNoError(t, err, "Failed to place tile")
+
+	pending := testGame.GetPendingTileSelection(playerID)
+	if pending == nil {
+		t.Fatal("expected a follow-up pending tile selection for ocean placement, got nil")
+	}
+	testutil.AssertEqual(t, "ocean", pending.TileType,
+		"Follow-up pending selection should be an ocean placement")
+
+	placedTile, err := testGame.Board().GetTile(targetCoords)
+	testutil.AssertNoError(t, err, "Failed to get placed tile")
+	testutil.AssertEqual(t, 0, len(placedTile.Bonuses),
+		"Bonuses should be cleared after placement")
+}
+
+// TestSelectTileAction_NegativeBonusBlocksUnaffordablePlacement verifies that
+// placing on a tile whose bonuses would push a basic resource below zero is
+// rejected before any board mutation. Mirrors the negative-output gate used
+// for card play.
+func TestSelectTileAction_NegativeBonusBlocksUnaffordablePlacement(t *testing.T) {
+	ctx := context.Background()
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+	stateRepo := game.NewInMemoryGameStateRepository()
+
+	testutil.StartTestGame(t, testGame)
+
+	playerID := testGame.TurnOrder()[0]
+	p, _ := testGame.GetPlayer(playerID)
+	testutil.SetPlayerCredits(ctx, p, 2)
+
+	tiles := testGame.Board().Tiles()
+	var targetIdx = -1
+	for i, tile := range tiles {
+		if tile.OccupiedBy == nil && tile.Type == shared.ResourceLandTile {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx == -1 {
+		t.Fatal("No unoccupied land tile found")
+	}
+	tiles[targetIdx].Bonuses = []board.TileBonus{
+		{Type: shared.ResourceCredit, Amount: -6},
+	}
+	targetCoords := tiles[targetIdx].Coordinates
+	testutil.AssertNoError(t, testGame.Board().SetTiles(ctx, tiles), "set tiles")
+
+	hexStr := formatHexCoords(targetCoords)
+	pendingSelection := &shared.PendingTileSelection{
+		TileType:       "city",
+		AvailableHexes: []string{hexStr},
+		Source:         "test",
+	}
+	testutil.AssertNoError(t, testGame.SetPendingTileSelection(ctx, playerID, pendingSelection), "set pending tile selection")
+
+	selectTileAction := tileAction.NewSelectTileAction(repo, cardRegistry, stateRepo, logger)
+	_, err := selectTileAction.Execute(ctx, testGame.ID(), playerID, hexStr)
+	if err == nil {
+		t.Fatal("expected placement to be rejected when player cannot afford negative bonus")
+	}
+
+	placedTile, getErr := testGame.Board().GetTile(targetCoords)
+	testutil.AssertNoError(t, getErr, "Failed to get tile")
+	if placedTile.OccupiedBy != nil {
+		t.Fatal("Tile should not have been placed when affordability check fails")
+	}
+	testutil.AssertEqual(t, 1, len(placedTile.Bonuses),
+		"Bonus should still be on the tile (placement rejected)")
+	testutil.AssertEqual(t, 2, p.Resources().Get().Credits,
+		"Player credits should be unchanged")
+}
+
+// TestSelectTileAction_NegativeBonusAppliedWhenAffordable verifies that the
+// affordability gate lets the placement proceed when the player has enough.
+func TestSelectTileAction_NegativeBonusAppliedWhenAffordable(t *testing.T) {
+	ctx := context.Background()
+	broadcaster := testutil.NewMockBroadcaster()
+	testGame, repo := testutil.CreateTestGameWithPlayers(t, 2, broadcaster)
+	logger := testutil.TestLogger()
+	cardRegistry := testutil.CreateTestCardRegistry()
+	stateRepo := game.NewInMemoryGameStateRepository()
+
+	testutil.StartTestGame(t, testGame)
+
+	playerID := testGame.TurnOrder()[0]
+	p, _ := testGame.GetPlayer(playerID)
+	testutil.SetPlayerCredits(ctx, p, 10)
+
+	tiles := testGame.Board().Tiles()
+	var targetIdx = -1
+	for i, tile := range tiles {
+		if tile.OccupiedBy == nil && tile.Type == shared.ResourceLandTile {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx == -1 {
+		t.Fatal("No unoccupied land tile found")
+	}
+	tiles[targetIdx].Bonuses = []board.TileBonus{
+		{Type: shared.ResourceCredit, Amount: -6},
+	}
+	targetCoords := tiles[targetIdx].Coordinates
+	testutil.AssertNoError(t, testGame.Board().SetTiles(ctx, tiles), "set tiles")
+
+	hexStr := formatHexCoords(targetCoords)
+	pendingSelection := &shared.PendingTileSelection{
+		TileType:       "city",
+		AvailableHexes: []string{hexStr},
+		Source:         "test",
+	}
+	testutil.AssertNoError(t, testGame.SetPendingTileSelection(ctx, playerID, pendingSelection), "set pending tile selection")
+
+	selectTileAction := tileAction.NewSelectTileAction(repo, cardRegistry, stateRepo, logger)
+	_, err := selectTileAction.Execute(ctx, testGame.ID(), playerID, hexStr)
+	testutil.AssertNoError(t, err, "Affordable negative bonus should not block placement")
+
+	testutil.AssertEqual(t, 4, p.Resources().Get().Credits,
+		"Player credits should drop by 6 (10 - 6 = 4)")
+}
+
 func getResourceAmount(p *player.Player, resourceType shared.ResourceType) int {
 	resources := p.Resources().Get()
 	switch resourceType {

--- a/backend/test/events/broadcasting_test.go
+++ b/backend/test/events/broadcasting_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/player"
 	"terraforming-mars-backend/internal/game/shared"
@@ -21,7 +22,7 @@ func TestBroadcasting_AutomaticOnStateChange(t *testing.T) {
 	}
 
 	// Create game without broadcaster
-	testGame := game.NewGame(ds, "test-game", "", settings)
+	testGame := game.NewGame(ds, "test-game", "", settings, board.GenerateMarsBoard(false))
 
 	// Add a player
 	ctx := context.Background()
@@ -42,7 +43,7 @@ func TestBroadcasting_MultipleStateChanges(t *testing.T) {
 		CardPacks:  []string{"base"},
 	}
 
-	testGame := game.NewGame(ds, "test-game", "", settings)
+	testGame := game.NewGame(ds, "test-game", "", settings, board.GenerateMarsBoard(false))
 	ctx := context.Background()
 
 	// Add multiple players
@@ -68,7 +69,7 @@ func TestBroadcasting_CorrectGameID(t *testing.T) {
 		CardPacks:  []string{"base"},
 	}
 
-	testGame := game.NewGame(ds, gameID, "", settings)
+	testGame := game.NewGame(ds, gameID, "", settings, board.GenerateMarsBoard(false))
 	ctx := context.Background()
 
 	// Add player and verify game ID
@@ -127,8 +128,8 @@ func TestBroadcasting_PerGameIsolation(t *testing.T) {
 		CardPacks:  []string{"base"},
 	}
 
-	game1 := game.NewGame(ds, "game-1", "", settings)
-	game2 := game.NewGame(ds, "game-2", "", settings)
+	game1 := game.NewGame(ds, "game-1", "", settings, board.GenerateMarsBoard(false))
+	game2 := game.NewGame(ds, "game-2", "", settings, board.GenerateMarsBoard(false))
 
 	ctx := context.Background()
 
@@ -165,7 +166,7 @@ func TestBroadcasting_WithoutBroadcaster(t *testing.T) {
 	}
 
 	// Create game without broadcaster
-	testGame := game.NewGame(ds, "test-game", "", settings)
+	testGame := game.NewGame(ds, "test-game", "", settings, board.GenerateMarsBoard(false))
 	ctx := context.Background()
 
 	// Perform operations

--- a/backend/test/integration/game_lifecycle_test.go
+++ b/backend/test/integration/game_lifecycle_test.go
@@ -21,7 +21,7 @@ func TestGameLifecycle_CreateJoinStartPlay(t *testing.T) {
 	ctx := context.Background()
 
 	// Create actions
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 	joinAction := gameAction.NewJoinGameAction(repo, cardRegistry, logger)
 	startAction := turnAction.NewStartGameAction(repo, nil, nil, nil, nil, nil, logger)
 
@@ -92,7 +92,7 @@ func TestGameLifecycle_MultipleGames(t *testing.T) {
 	logger := testutil.TestLogger()
 	ctx := context.Background()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 	joinAction := gameAction.NewJoinGameAction(repo, cardRegistry, logger)
 
 	// Create 3 games
@@ -135,7 +135,7 @@ func TestGameLifecycle_PlayerReconnection(t *testing.T) {
 	logger := testutil.TestLogger()
 	ctx := context.Background()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 	joinAction := gameAction.NewJoinGameAction(repo, cardRegistry, logger)
 
 	// Create game
@@ -167,7 +167,7 @@ func TestGameLifecycle_SoloMode(t *testing.T) {
 	logger := testutil.TestLogger()
 	ctx := context.Background()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 	joinAction := gameAction.NewJoinGameAction(repo, cardRegistry, logger)
 	startAction := turnAction.NewStartGameAction(repo, nil, nil, nil, nil, nil, logger)
 
@@ -203,7 +203,7 @@ func TestGameLifecycle_GameStateConsistency(t *testing.T) {
 	logger := testutil.TestLogger()
 	ctx := context.Background()
 
-	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, logger)
+	createAction := gameAction.NewCreateGameAction(repo, cardRegistry, testutil.CreateTestMapRegistry(), logger)
 	joinAction := gameAction.NewJoinGameAction(repo, cardRegistry, logger)
 
 	// Create game

--- a/backend/test/testutil/test_helpers.go
+++ b/backend/test/testutil/test_helpers.go
@@ -15,10 +15,12 @@ import (
 	"terraforming-mars-backend/internal/awards"
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	gamecards "terraforming-mars-backend/internal/game/cards"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/internal/logger"
+	"terraforming-mars-backend/internal/maps"
 	"terraforming-mars-backend/internal/milestones"
 )
 
@@ -131,7 +133,7 @@ func CreateTestGameWithPlayers(t *testing.T, numPlayers int, broadcaster *MockBr
 		CardPacks:  []string{"base-game"},
 	}
 
-	testGame := game.NewGame(repo.DataStore(), "test-game-id", "", settings)
+	testGame := game.NewGame(repo.DataStore(), "test-game-id", "", settings, board.GenerateMarsBoard(false))
 	allCards := cardRegistry.GetAll()
 
 	// Separate cards by type
@@ -196,7 +198,7 @@ func CreateTestGameWithVenus(t *testing.T, numPlayers int, broadcaster *MockBroa
 		VenusNextEnabled: true,
 	}
 
-	testGame := game.NewGame(repo.DataStore(), "test-game-id", "", settings)
+	testGame := game.NewGame(repo.DataStore(), "test-game-id", "", settings, board.GenerateMarsBoard(settings.VenusNextEnabled))
 	allCards := cardRegistry.GetAll()
 
 	projectCards := make([]string, 0)
@@ -301,3 +303,14 @@ func TagPtr(v shared.CardTag) *shared.CardTag { return &v }
 
 // ResourceTypePtr returns a pointer to the given ResourceType value.
 func ResourceTypePtr(v shared.ResourceType) *shared.ResourceType { return &v }
+
+// CreateTestMapRegistry returns a MapRegistry loaded from the JSON database.
+func CreateTestMapRegistry() *maps.MapRegistry {
+	_, currentFile, _, _ := runtime.Caller(0)
+	jsonPath := filepath.Join(filepath.Dir(currentFile), "..", "..", "assets", "terraforming_mars_maps.json")
+	registry, err := maps.LoadMapsFromJSON(jsonPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load map DB for tests: %v", err))
+	}
+	return registry
+}

--- a/backend/test/websocket/broadcaster_test.go
+++ b/backend/test/websocket/broadcaster_test.go
@@ -8,6 +8,7 @@ import (
 
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/datastore"
 	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/test/testutil"
@@ -304,7 +305,7 @@ func TestBroadcaster_GameStateChanges(t *testing.T) {
 
 	ds, err := datastore.NewDataStore()
 	testutil.AssertNoError(t, err, "create datastore")
-	testGame := game.NewGame(ds, "test-game", "", settings)
+	testGame := game.NewGame(ds, "test-game", "", settings, board.GenerateMarsBoard(false))
 	ctx := context.Background()
 
 	// Trigger state change

--- a/frontend/src/components/game/board/TileGrid.tsx
+++ b/frontend/src/components/game/board/TileGrid.tsx
@@ -177,11 +177,12 @@ export default function TileGrid({
     setTooltipData(null);
   }, []);
 
-  // Convert hex coordinates to 2D pixel position (same as backend logic)
+  // Convert hex coordinates to 2D pixel position (same as backend logic).
+  // y is negated so JSON row 0 (r = -radius, "north") maps to sphere +Y.
   const hexToPixel = (coord: { q: number; r: number; s: number }) => {
-    const size = 0.3; // Same as HEX_SIZE in HexGrid2D
+    const size = 0.3;
     const x = size * Math.sqrt(3) * (coord.q + coord.r / 2);
-    const y = ((size * 3) / 2) * coord.r;
+    const y = -((size * 3) / 2) * coord.r;
     return { x, y };
   };
 
@@ -201,7 +202,7 @@ export default function TileGrid({
     // Use backend tiles if available (filter to Mars-only)
     if (gameState?.board?.tiles) {
       return gameState.board.tiles
-        .filter((tile: TileDto) => tile.location === "mars")
+        .filter((tile: TileDto) => tile.location === "mars" && tile.type !== "empty")
         .map((tile: TileDto): ProjectedTile => {
           // Convert hex coordinate to 2D position for projection
           const position2D = hexToPixel(tile.coordinates);

--- a/frontend/src/components/game/board/oceanDataTexture.ts
+++ b/frontend/src/components/game/board/oceanDataTexture.ts
@@ -19,7 +19,7 @@ const HEX_SIZE = 0.3;
 
 export function hexToPixel(coord: HexCoordinate): { x: number; y: number } {
   const x = HEX_SIZE * Math.sqrt(3) * (coord.q + coord.r / 2);
-  const y = ((HEX_SIZE * 3) / 2) * coord.r;
+  const y = -((HEX_SIZE * 3) / 2) * coord.r;
   return { x, y };
 }
 

--- a/frontend/src/components/pages/CreateGamePage.tsx
+++ b/frontend/src/components/pages/CreateGamePage.tsx
@@ -58,12 +58,14 @@ const CreateGamePage: React.FC = () => {
       // Step 1: Create game
       const gameSettings: GameSettingsDto = {
         maxPlayers: maxPlayers,
+        mapId: "tharsis",
         venusNextEnabled: venusNextEnabled,
         developmentMode: developmentMode,
         cardPacks: selectedPacks,
         demoGame: demoGame,
         hasClaudeApiKey: !!claudeApiKey.trim(),
         availablePlayerColors: [],
+        availableMaps: [],
       };
 
       const game = await apiService.createGame(gameSettings, claudeApiKey.trim() || undefined);

--- a/frontend/src/components/ui/lobby/MapPreview.tsx
+++ b/frontend/src/components/ui/lobby/MapPreview.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import type { MapPreviewTile } from "../../../types/generated/api-types.ts";
+
+interface MapPreviewProps {
+  tiles: MapPreviewTile[];
+}
+
+const HEX_SIZE = 14;
+const SQRT3 = Math.sqrt(3);
+
+function hexToPixel(q: number, r: number): { x: number; y: number } {
+  const x = HEX_SIZE * SQRT3 * (q + r / 2);
+  const y = ((HEX_SIZE * 3) / 2) * r;
+  return { x, y };
+}
+
+function hexPoints(cx: number, cy: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 180) * (60 * i - 30);
+    const px = cx + HEX_SIZE * Math.cos(angle);
+    const py = cy + HEX_SIZE * Math.sin(angle);
+    points.push(`${px},${py}`);
+  }
+  return points.join(" ");
+}
+
+function getTileColor(tile: MapPreviewTile): string {
+  if (tile.type === "ocean-space") {
+    return "#1a5276";
+  }
+  if (tile.type === "restricted-tile") {
+    return "#4a1a1a";
+  }
+  if (tile.volcanic) {
+    return "#8b3a2a";
+  }
+  return "#5c4a32";
+}
+
+const MapPreview: React.FC<MapPreviewProps> = ({ tiles }) => {
+  const visibleTiles = tiles.filter((t) => t.type !== "empty" && t.type !== "restricted-tile");
+
+  if (visibleTiles.length === 0) {
+    return null;
+  }
+
+  const positions = visibleTiles.map((tile) => {
+    const pos = hexToPixel(tile.q, tile.r);
+    return { tile, ...pos };
+  });
+
+  const xs = positions.map((p) => p.x);
+  const ys = positions.map((p) => p.y);
+  const minX = Math.min(...xs) - HEX_SIZE - 2;
+  const maxX = Math.max(...xs) + HEX_SIZE + 2;
+  const minY = Math.min(...ys) - HEX_SIZE - 2;
+  const maxY = Math.max(...ys) + HEX_SIZE + 2;
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+
+  return (
+    <svg
+      viewBox={`${minX} ${minY} ${width} ${height}`}
+      width={width * 1.2}
+      height={height * 1.2}
+      className="block"
+    >
+      {positions.map((p) => (
+        <polygon
+          key={`${p.tile.q},${p.tile.r},${p.tile.s}`}
+          points={hexPoints(p.x, p.y)}
+          fill={getTileColor(p.tile)}
+          stroke="rgba(255,255,255,0.15)"
+          strokeWidth={0.5}
+        />
+      ))}
+    </svg>
+  );
+};
+
+export default MapPreview;

--- a/frontend/src/components/ui/overlay/WaitingRoomOverlay.tsx
+++ b/frontend/src/components/ui/overlay/WaitingRoomOverlay.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { GameDto, OtherPlayerDto, PlayerDto } from "../../../types/generated/api-types.ts";
 import { globalWebSocketManager } from "../../../services/globalWebSocketManager.ts";
@@ -8,6 +9,8 @@ import GameMenuModal from "./GameMenuModal.tsx";
 import DemoSetupOverlay from "./DemoSetupOverlay.tsx";
 import { BotDifficultyChip, BotSpeedChip } from "../display/BotChips.tsx";
 import MainMenuHamburger from "../buttons/MainMenuHamburger.tsx";
+import MapPreview from "../lobby/MapPreview.tsx";
+import { Z_INDEX } from "@/constants/zIndex.ts";
 
 interface WaitingRoomOverlayProps {
   game: GameDto;
@@ -61,6 +64,53 @@ const ColorPicker: React.FC<{
   </div>
 );
 
+const MapDropdownPortal: React.FC<{
+  anchorEl: HTMLElement;
+  maps: { id: string; name: string; description: string }[];
+  selectedMapId: string;
+  onSelect: (id: string) => void;
+  onHover: (id: string | null) => void;
+}> = ({ anchorEl, maps, selectedMapId, onSelect, onHover }) => {
+  const rect = anchorEl.getBoundingClientRect();
+
+  return (
+    <div
+      id="map-dropdown-portal"
+      className="fixed bg-black/95 border border-white/20 rounded-lg overflow-hidden shadow-lg max-h-[300px] overflow-y-auto backdrop-blur-sm"
+      style={{
+        zIndex: Z_INDEX.POPOVER,
+        top: rect.bottom + 4,
+        left: rect.left,
+        width: rect.width,
+      }}
+    >
+      {maps.map((m) => (
+        <button
+          key={m.id}
+          onClick={() => onSelect(m.id)}
+          onMouseEnter={() => onHover(m.id)}
+          onMouseLeave={() => onHover(null)}
+          className={`w-full flex flex-col gap-0.5 px-3 py-2.5 text-left transition-colors border-b border-white/10 last:border-b-0 ${
+            m.id === selectedMapId
+              ? "text-white bg-space-blue-800/60"
+              : "text-white/80 hover:bg-white/10"
+          }`}
+        >
+          <div className="flex items-center justify-between w-full">
+            <span className="text-sm font-medium">{m.name}</span>
+            {m.id === selectedMapId && (
+              <span className="bg-space-blue-900 text-white py-0.5 px-1.5 rounded text-[10px] font-bold uppercase">
+                Selected
+              </span>
+            )}
+          </div>
+          <span className="text-[11px] text-white/40 leading-tight">{m.description}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
 const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
   game,
   playerId,
@@ -75,8 +125,11 @@ const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
   const [pendingLeave, setPendingLeave] = useState(false);
   const [showBotDropdown, setShowBotDropdown] = useState(false);
   const [colorPickerForPlayer, setColorPickerForPlayer] = useState<string | null>(null);
+  const [showMapDropdown, setShowMapDropdown] = useState(false);
+  const [hoveredMapId, setHoveredMapId] = useState<string | null>(null);
   const botDropdownRef = useRef<HTMLDivElement>(null);
   const colorPickerRef = useRef<HTMLDivElement>(null);
+  const mapDropdownRef = useRef<HTMLDivElement>(null);
 
   const isDemoGame = game.settings.demoGame;
   const [showDemoSetup, setShowDemoSetup] = useState(false);
@@ -229,7 +282,7 @@ const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
   };
 
   useEffect(() => {
-    if (!showBotDropdown && !colorPickerForPlayer) return;
+    if (!showBotDropdown && !colorPickerForPlayer && !showMapDropdown) return;
     const handleClick = (e: MouseEvent) => {
       if (
         showBotDropdown &&
@@ -245,15 +298,37 @@ const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
       ) {
         setColorPickerForPlayer(null);
       }
+      if (showMapDropdown && mapDropdownRef.current) {
+        const portalEl = document.getElementById("map-dropdown-portal");
+        const inButton = mapDropdownRef.current.contains(e.target as Node);
+        const inPortal = portalEl?.contains(e.target as Node);
+        if (!inButton && !inPortal) {
+          setShowMapDropdown(false);
+          setHoveredMapId(null);
+        }
+      }
     };
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [showBotDropdown, colorPickerForPlayer]);
+  }, [showBotDropdown, colorPickerForPlayer, showMapDropdown]);
 
   const handleAddBot = (difficulty: string, speed: string) => {
     setShowBotDropdown(false);
     void globalWebSocketManager.addBot(undefined, difficulty, speed);
   };
+
+  const handleMapSelect = (mapId: string) => {
+    if (!isHost) return;
+    setShowMapDropdown(false);
+    setHoveredMapId(null);
+    void globalWebSocketManager.updateGameMap(mapId);
+  };
+
+  const availableMaps = game.settings.availableMaps || [];
+  const currentMapName =
+    availableMaps.find((m) => m.id === game.settings.mapId)?.name ||
+    game.settings.mapId ||
+    "Tharsis";
 
   return (
     <>
@@ -606,6 +681,42 @@ const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
           </div>
         </div>
 
+        {/* Map Selector */}
+        {availableMaps.length > 0 && (
+          <div className="mb-6">
+            <h3 className="text-white text-sm font-semibold mb-2 uppercase tracking-wide">Map</h3>
+            <div ref={mapDropdownRef}>
+              <button
+                onClick={() => {
+                  if (isHost) {
+                    setShowMapDropdown((prev) => !prev);
+                  }
+                }}
+                className={`w-full flex items-center justify-between py-2 px-3 bg-black/40 rounded-lg border border-space-blue-600/50 text-white text-sm font-medium transition-colors ${
+                  isHost ? "cursor-pointer hover:border-space-blue-400" : "cursor-default"
+                }`}
+              >
+                <span>{currentMapName}</span>
+                {isHost && (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className={`transition-transform ${showMapDropdown ? "rotate-180" : ""}`}
+                  >
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Demo Game: Configure button */}
         {isDemoGame && (
           <div className="text-center">
@@ -640,6 +751,42 @@ const WaitingRoomOverlay: React.FC<WaitingRoomOverlayProps> = ({
           <p className="text-white/50 text-sm text-center">Waiting for host to start the game...</p>
         )}
       </GameMenuModal>
+
+      {/* Map Dropdown Options (portal - outside modal to avoid overflow) */}
+      {showMapDropdown &&
+        isHost &&
+        mapDropdownRef.current &&
+        createPortal(
+          <MapDropdownPortal
+            anchorEl={mapDropdownRef.current}
+            maps={availableMaps}
+            selectedMapId={game.settings.mapId}
+            onSelect={handleMapSelect}
+            onHover={setHoveredMapId}
+          />,
+          document.body,
+        )}
+
+      {/* Map Preview Popover (portal) */}
+      {hoveredMapId &&
+        showMapDropdown &&
+        mapDropdownRef.current &&
+        createPortal(
+          <div
+            className="fixed bg-space-black-darker/95 border border-space-blue-400/50 rounded-xl p-4 backdrop-blur-sm shadow-[0_10px_40px_rgba(0,0,0,0.6)]"
+            style={{
+              zIndex: Z_INDEX.POPOVER,
+              top: mapDropdownRef.current.getBoundingClientRect().bottom - 200,
+              left: mapDropdownRef.current.getBoundingClientRect().right + 12,
+            }}
+          >
+            <p className="text-white/70 text-xs font-semibold uppercase tracking-wide mb-2 text-center">
+              {availableMaps.find((m) => m.id === hoveredMapId)?.name}
+            </p>
+            <MapPreview tiles={availableMaps.find((m) => m.id === hoveredMapId)?.tiles || []} />
+          </div>,
+          document.body,
+        )}
 
       {/* Demo Setup Overlay */}
       {isDemoGame && showDemoSetup && game && playerId && (

--- a/frontend/src/hooks/useTextures.ts
+++ b/frontend/src/hooks/useTextures.ts
@@ -46,6 +46,16 @@ const RESOURCE_ICON_PATHS = {
   plant: "/assets/resources/plant.png",
   megacredit: "/assets/resources/megacredit.png",
   card: "/assets/resources/card.png",
+  heat: "/assets/resources/heat.png",
+  power: "/assets/resources/power.png",
+  microbe: "/assets/resources/microbe.png",
+  animal: "/assets/resources/animal.png",
+  science: "/assets/resources/science.png",
+  data: "/assets/resources/data.png",
+  director: "/assets/resources/director.png",
+  temperature: "/assets/global-parameters/temperature.png",
+  ocean: "/assets/tiles/ocean.png",
+  wild: "/assets/resources/wild.png",
 } as const;
 
 type ResourceIconName = keyof typeof RESOURCE_ICON_PATHS;
@@ -58,6 +68,17 @@ const BONUS_TYPE_TO_ICON: Record<string, ResourceIconName> = {
   cards: "card",
   "card-draw": "card",
   credit: "megacredit",
+  heat: "heat",
+  energy: "power",
+  "energy-production": "power",
+  microbe: "microbe",
+  animal: "animal",
+  science: "science",
+  data: "data",
+  delegate: "director",
+  temperature: "temperature",
+  ocean: "ocean",
+  "ocean-placement": "ocean",
 };
 
 // Module-level preloads
@@ -100,6 +121,16 @@ useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.titanium);
 useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.plant);
 useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.megacredit);
 useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.card);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.heat);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.power);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.microbe);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.animal);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.science);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.data);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.director);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.temperature);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.ocean);
+useLoader.preload(THREE.TextureLoader, RESOURCE_ICON_PATHS.wild);
 
 interface TextureAssets {
   mars: THREE.Texture;
@@ -182,6 +213,16 @@ export function useTextures(): TextureAssets {
   const plantIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.plant);
   const megacreditIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.megacredit);
   const cardIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.card);
+  const heatIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.heat);
+  const powerIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.power);
+  const microbeIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.microbe);
+  const animalIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.animal);
+  const scienceIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.science);
+  const dataIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.data);
+  const directorIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.director);
+  const temperatureIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.temperature);
+  const oceanIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.ocean);
+  const wildIcon = useLoader(THREE.TextureLoader, RESOURCE_ICON_PATHS.wild);
 
   // Configure textures (idempotent — drei caches texture objects by path)
   useMemo(() => {
@@ -276,15 +317,41 @@ export function useTextures(): TextureAssets {
       plant: plantIcon,
       megacredit: megacreditIcon,
       card: cardIcon,
+      heat: heatIcon,
+      power: powerIcon,
+      microbe: microbeIcon,
+      animal: animalIcon,
+      science: scienceIcon,
+      data: dataIcon,
+      director: directorIcon,
+      temperature: temperatureIcon,
+      ocean: oceanIcon,
+      wild: wildIcon,
     }),
-    [steelIcon, titaniumIcon, plantIcon, megacreditIcon, cardIcon],
+    [
+      steelIcon,
+      titaniumIcon,
+      plantIcon,
+      megacreditIcon,
+      cardIcon,
+      heatIcon,
+      powerIcon,
+      microbeIcon,
+      animalIcon,
+      scienceIcon,
+      dataIcon,
+      directorIcon,
+      temperatureIcon,
+      oceanIcon,
+      wildIcon,
+    ],
   );
 
   const getResourceIcon = useMemo(
     () =>
       (bonusType: string): THREE.Texture => {
         const iconName = BONUS_TYPE_TO_ICON[bonusType];
-        return iconName ? resourceIcons[iconName] : resourceIcons.megacredit;
+        return iconName ? resourceIcons[iconName] : resourceIcons.wild;
       },
     [resourceIcons],
   );

--- a/frontend/src/services/globalWebSocketManager.ts
+++ b/frontend/src/services/globalWebSocketManager.ts
@@ -361,6 +361,11 @@ class GlobalWebSocketManager implements WebSocketConnection {
     webSocketService.requestLogs();
   }
 
+  async updateGameMap(mapId: string): Promise<void> {
+    await this.ensureConnected();
+    webSocketService.updateGameMap(mapId);
+  }
+
   async setPlayerColor(color: string, targetPlayerId?: string): Promise<void> {
     await this.ensureConnected();
     webSocketService.setPlayerColor(color, targetPlayerId);

--- a/frontend/src/services/webSocketService.ts
+++ b/frontend/src/services/webSocketService.ts
@@ -52,6 +52,7 @@ import {
   MessageTypeChatUpdate,
   MessageTypeKickSpectator,
   MessageTypeSpectatorKicked,
+  MessageTypeUpdateGameMap,
   MessageTypeActionColonyTrade,
   MessageTypeActionColonyBuild,
   MessageTypeActionProjectFundingSeat,
@@ -434,6 +435,10 @@ export class WebSocketService {
 
   requestLogs(): void {
     this.send(MessageTypeRequestLogs, {});
+  }
+
+  updateGameMap(mapId: string): void {
+    this.send(MessageTypeUpdateGameMap, { mapId });
   }
 
   setPlayerColor(color: string, targetPlayerId?: string): void {

--- a/frontend/src/types/generated/api-types.ts
+++ b/frontend/src/types/generated/api-types.ts
@@ -860,6 +860,7 @@ export interface ProductionPhaseOtherPlayerDto {
  */
 export interface GameSettingsDto {
   maxPlayers: number /* int */;
+  mapId: string;
   venusNextEnabled: boolean;
   developmentMode: boolean;
   demoGame: boolean;
@@ -867,10 +868,31 @@ export interface GameSettingsDto {
   hasClaudeApiKey: boolean;
   claudeModel?: string;
   availablePlayerColors: string[];
+  availableMaps: MapInfoDto[];
   temperature?: number /* int */;
   oxygen?: number /* int */;
   oceans?: number /* int */;
   generation?: number /* int */;
+}
+/**
+ * MapInfoDto contains basic map info for the frontend
+ */
+export interface MapInfoDto {
+  id: string;
+  name: string;
+  description: string;
+  tiles: MapPreviewTile[];
+}
+/**
+ * MapPreviewTile contains minimal tile data for map preview
+ */
+export interface MapPreviewTile {
+  q: number /* int */;
+  r: number /* int */;
+  s: number /* int */;
+  type: string;
+  volcanic?: boolean;
+  tags?: string[];
 }
 /**
  * PendingDemoChoicesDto contains a player's demo lobby card selections
@@ -1914,6 +1936,7 @@ export interface Registries {
   StandardProjectRegistry: any /* standardprojects.StandardProjectRegistry */;
   AwardRegistry: any /* awards.AwardRegistry */;
   MilestoneRegistry: any /* milestones.MilestoneRegistry */;
+  AvailableMaps: MapInfoDto[];
 }
 
 //////////
@@ -1991,6 +2014,7 @@ export const MessageTypePlayerKicked: MessageType = "player-kicked";
 export const MessageTypeConvertToBot: MessageType = "convert-to-bot";
 export const MessageTypeEndGame: MessageType = "end-game";
 export const MessageTypeGameEnded: MessageType = "game-ended";
+export const MessageTypeUpdateGameMap: MessageType = "update-game-map";
 export const MessageTypeSetPlayerColor: MessageType = "set-player-color";
 export const MessageTypeSpectatorConnect: MessageType = "spectator-connect";
 export const MessageTypeSpectatorConnected: MessageType = "spectator-connected";


### PR DESCRIPTION
### Maps & data
- Added 10 Mars map definitions in `backend/assets/terraforming_mars_maps.json` (Tharsis, Hellas, Elysium, Arabia Terra, Amazonis Planitia, Terra Cimmeria, Vastitas Borealis, Utopia Planitia, Vastitas Borealis Nova, Hollandia)
- New `internal/maps` package loads JSON maps and builds board tiles
- `NewGame` now takes initial tiles instead of generating them internally

### Lobby flow
- Map selector and 2D preview in `CreateGamePage` and `WaitingRoomOverlay`
- Host can change the map during the lobby; backend broadcasts available maps + selected map id over WebSocket
- `update-game-map` outbound WebSocket message

### Tile bonus handling
- Backend awards `heat`, `energy`, `temperature`, `oxygen`, `*-production`, and `ocean-placement` bonuses (previously dropped silently)
- `temperature` and `oxygen` bonuses raise the global parameter and grant the standard +1 TR per step
- `ocean-placement` queues a follow-up tile placement so the player picks the ocean hex
- Negative-amount bonuses (e.g. ` credit -3`, `credit -6`) are gated by `CanAffordResourceDeduction` — extracted from the existing card-output validation so the same affordability rule applies to tile bonuses

### Frontend rendering
- 3D hex grid loads icons for all bonus types in the new maps; unknown types fall back to `wild.png` instead of credits
- Hex y-axis flipped so JSON row 0 maps to the sphere's north pole (matches the 2D preview)
- Empty tiles skipped on the 3D grid

### Tests
- `tile_placement_bonus_test.go`: multi-bonus tile, ocean-placement bonus queues follow-up selection, affordability gate blocks unaffordable placements and lets affordable ones through

Closes #550