### PR TITLE
feat(frontend): show active milestones and awards in top bar

### DIFF
--- a/frontend/src/components/layout/panels/MilestoneAwardStatusStrip.tsx
+++ b/frontend/src/components/layout/panels/MilestoneAwardStatusStrip.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useGameStore } from "@/stores/gameStore.ts";
+import { AwardDto, MilestoneDto } from "@/types/generated/api-types.ts";
+import GameIcon from "../../ui/display/GameIcon.tsx";
+import DecorBoxTooltip from "../../ui/display/DecorBoxTooltip.tsx";
+import AwardScoreboard from "../../ui/display/AwardScoreboard.tsx";
+import { FormattedDescription } from "../../ui/display/FormattedDescription.tsx";
+import ParallelogramButton, { ANGLE_INDENT, BUTTON_SPACING } from "./ParallelogramButton.tsx";
+
+const SLOTS_PER_SIDE = 3;
+const CHIP_WIDTH = 84;
+const INNER_CHIP_WIDTH = CHIP_WIDTH - 12;
+const CHIP_HEIGHT = 40;
+const PLACEHOLDER_COLOR = "#374151";
+const MILESTONE_FALLBACK_COLOR = "#ff6b35";
+const AWARD_FALLBACK_COLOR = "#f39c12";
+
+interface PlayerInfo {
+  id: string;
+  name: string;
+  color: string;
+}
+
+type ChipKind = "milestone" | "award";
+type HoverTarget = { kind: ChipKind; slot: number } | null;
+
+const useSlotRefs = () => {
+  const ref0 = useRef<HTMLButtonElement>(null);
+  const ref1 = useRef<HTMLButtonElement>(null);
+  const ref2 = useRef<HTMLButtonElement>(null);
+  return [ref0, ref1, ref2] as const;
+};
+
+const MilestoneAwardStatusStrip: React.FC = () => {
+  const game = useGameStore((state) => state.game);
+
+  const milestoneRefs = useSlotRefs();
+  const awardRefs = useSlotRefs();
+
+  const [hovered, setHovered] = useState<HoverTarget>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+
+  const allPlayers: PlayerInfo[] = useMemo(() => {
+    if (!game) {
+      return [];
+    }
+    const players: PlayerInfo[] = [];
+    if (game.currentPlayer?.id) {
+      players.push({
+        id: game.currentPlayer.id,
+        name: game.currentPlayer.name,
+        color: game.currentPlayer.color,
+      });
+    }
+    for (const p of game.otherPlayers ?? []) {
+      players.push({ id: p.id, name: p.name, color: p.color });
+    }
+    return players;
+  }, [game]);
+
+  const claimedMilestones = useMemo(
+    () => (game?.milestones ?? []).filter((m) => m.isClaimed),
+    [game?.milestones],
+  );
+  const fundedAwards = useMemo(
+    () => (game?.awards ?? []).filter((a) => a.isFunded),
+    [game?.awards],
+  );
+
+  useEffect(() => {
+    if (!hovered) {
+      setTooltipPos(null);
+      return;
+    }
+    const refList = hovered.kind === "milestone" ? milestoneRefs : awardRefs;
+    const el = refList[hovered.slot].current;
+    if (!el) {
+      setTooltipPos(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    setTooltipPos({ x: rect.left + rect.width / 2, y: rect.bottom });
+  }, [hovered, milestoneRefs, awardRefs]);
+
+  if (!game) {
+    return null;
+  }
+
+  const hoveredItem = (() => {
+    if (!hovered) {
+      return null;
+    }
+    return hovered.kind === "milestone"
+      ? (claimedMilestones[hovered.slot] ?? null)
+      : (fundedAwards[hovered.slot] ?? null);
+  })();
+  const hoveredPlayerId = hoveredItem
+    ? hovered?.kind === "milestone"
+      ? (hoveredItem as MilestoneDto).claimedBy
+      : (hoveredItem as AwardDto).fundedBy
+    : undefined;
+  const hoveredPlayer = allPlayers.find((p) => p.id === hoveredPlayerId);
+  const hoveredLabel = hovered?.kind === "milestone" ? "Claimed by " : "Funded by ";
+
+  // Slot index meaning: 0 = innermost (next to where the two groups meet), SLOTS_PER_SIDE-1 = outermost.
+  // Render order for milestones: outermost first (left-to-right places slot 2 → slot 0).
+  // Render order for awards: innermost first (left-to-right places slot 0 → slot 2).
+  type Connect = "none" | "overlap" | "gap";
+  const renderSlot = (kind: ChipKind, slot: number, connect: Connect) => {
+    const isMilestone = kind === "milestone";
+    const filled = isMilestone ? (claimedMilestones[slot] ?? null) : (fundedAwards[slot] ?? null);
+    const ref = isMilestone ? milestoneRefs[slot] : awardRefs[slot];
+    const isFilled = filled !== null;
+    const isInnermost = slot === 0;
+
+    const fallbackColor = isMilestone ? MILESTONE_FALLBACK_COLOR : AWARD_FALLBACK_COLOR;
+    const ownerId = isMilestone
+      ? (filled as MilestoneDto | null)?.claimedBy
+      : (filled as AwardDto | null)?.fundedBy;
+    const ownerColor = allPlayers.find((p) => p.id === ownerId)?.color;
+    const chipColor = isFilled ? (ownerColor ?? fallbackColor) : PLACEHOLDER_COLOR;
+
+    const slopedLeft = isMilestone ? "slope-right" : "slope-left";
+    const slopedRight = isMilestone ? "slope-left" : "slope-right";
+    const leftEdge = isMilestone ? slopedLeft : isInnermost ? "flat" : slopedLeft;
+    const rightEdge = isMilestone ? (isInnermost ? "flat" : slopedRight) : slopedRight;
+    const overlapMargin = -ANGLE_INDENT + BUTTON_SPACING;
+    const marginLeft = connect === "none" ? 0 : connect === "gap" ? BUTTON_SPACING : overlapMargin;
+
+    const handleEnter = () => {
+      if (!isFilled) {
+        return;
+      }
+      setHovered({ kind, slot });
+    };
+    const handleLeave = () => {
+      setHovered((current) => {
+        if (!current) {
+          return current;
+        }
+        if (current.kind === kind && current.slot === slot) {
+          return null;
+        }
+        return current;
+      });
+    };
+
+    const wrapperClass = isFilled ? "" : "pointer-events-none opacity-30";
+    const iconType = filled?.style?.icon;
+    const zIndex = isMilestone ? slot + 1 : SLOTS_PER_SIDE - slot;
+
+    return (
+      <div
+        key={`${kind}-${slot}`}
+        className={`relative ${wrapperClass}`}
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+        style={{
+          marginLeft,
+          zIndex,
+        }}
+      >
+        <ParallelogramButton
+          buttonRef={ref}
+          width={isInnermost ? INNER_CHIP_WIDTH : CHIP_WIDTH}
+          height={CHIP_HEIGHT}
+          color={chipColor}
+          leftEdge={leftEdge}
+          rightEdge={rightEdge}
+        >
+          {iconType ? <GameIcon iconType={iconType} size="small" /> : null}
+        </ParallelogramButton>
+      </div>
+    );
+  };
+
+  const milestoneOrder = [2, 1, 0];
+  const awardOrder = [0, 1, 2];
+
+  return (
+    <>
+      <div className="flex items-center pointer-events-auto">
+        {milestoneOrder.map((slot, i) =>
+          renderSlot("milestone", slot, i === 0 ? "none" : "overlap"),
+        )}
+        {awardOrder.map((slot, i) => renderSlot("award", slot, i === 0 ? "gap" : "overlap"))}
+      </div>
+      <DecorBoxTooltip position={tooltipPos} maxWidth={hovered?.kind === "award" ? 320 : 260}>
+        {hoveredItem ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-baseline justify-between gap-3">
+                <div className="font-orbitron font-bold text-white text-[12px] leading-tight">
+                  {hoveredItem.name}
+                </div>
+                <div className="text-white/70 text-[10px] leading-tight text-right shrink-0">
+                  {hoveredLabel}
+                  <span style={{ color: hoveredPlayer?.color ?? "#ffffff" }}>
+                    {hoveredPlayer?.name ?? "Unknown"}
+                  </span>
+                </div>
+              </div>
+              {hoveredItem.description && (
+                <div className="text-white/70 text-[10px] leading-tight">
+                  <FormattedDescription text={hoveredItem.description} />
+                </div>
+              )}
+            </div>
+            {hovered?.kind === "award" && (
+              <AwardScoreboard
+                players={allPlayers}
+                playerProgress={(hoveredItem as AwardDto).playerProgress ?? {}}
+              />
+            )}
+          </div>
+        ) : null}
+      </DecorBoxTooltip>
+    </>
+  );
+};
+
+export default MilestoneAwardStatusStrip;

--- a/frontend/src/components/layout/panels/ParallelogramButton.tsx
+++ b/frontend/src/components/layout/panels/ParallelogramButton.tsx
@@ -79,9 +79,7 @@ const ParallelogramButton: React.FC<ParallelogramButtonProps> = ({
 
   const handleMouseEnter = () => {
     setIsHovered(true);
-    if (isClickable) {
-      hoverSound.onMouseEnter?.();
-    }
+    hoverSound.onMouseEnter?.();
   };
 
   const cursorClass = isClickable ? "cursor-pointer" : "cursor-default";

--- a/frontend/src/components/layout/panels/ParallelogramButton.tsx
+++ b/frontend/src/components/layout/panels/ParallelogramButton.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from "react";
+import { useHoverSound } from "@/hooks/useHoverSound.ts";
+
+export const ANGLE_INDENT = 20;
+export const BUTTON_SPACING = 6;
+const BORDER_COLOR = "rgba(60,60,70,0.7)";
+
+export type EdgeStyle = "slope-left" | "slope-right" | "flat";
+
+export interface ParallelogramButtonProps {
+  width: number;
+  height: number;
+  color: string;
+  children?: React.ReactNode;
+  onClick?: () => void;
+  buttonRef?: React.RefObject<HTMLButtonElement | null>;
+  isActive?: boolean;
+  leftEdge?: EdgeStyle;
+  rightEdge?: EdgeStyle;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const ParallelogramButton: React.FC<ParallelogramButtonProps> = ({
+  width,
+  height,
+  color,
+  children,
+  onClick,
+  buttonRef,
+  isActive = false,
+  leftEdge: left = "flat",
+  rightEdge: right = "flat",
+  className = "",
+  style: extraStyle,
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const hoverSound = useHoverSound();
+  const active = isHovered || isActive;
+  const isClickable = typeof onClick === "function";
+
+  const ai = ANGLE_INDENT;
+  const w = width;
+  const h = height;
+
+  // slope-left (\): top indented, bottom at edge
+  // slope-right (/): top at edge, bottom indented
+  const tl = left === "slope-left" ? ai : 0;
+  const bl = left === "slope-right" ? ai : 0;
+  const tr = right === "slope-left" ? w - ai : w;
+  const br = right === "slope-right" ? w - ai : w;
+
+  const fillPoints = `${tl},0 ${tr},0 ${br},${h} ${bl},${h}`;
+  const contentOffsetX = (tl + tr + br + bl) / 4 - w / 2;
+
+  const edges: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
+  if (left === "slope-left") {
+    edges.push({ x1: ai, y1: 0, x2: 0, y2: h });
+  } else if (left === "slope-right") {
+    edges.push({ x1: 0, y1: 0, x2: ai, y2: h });
+  } else {
+    edges.push({ x1: 0, y1: 0, x2: 0, y2: h });
+  }
+  if (right === "slope-left") {
+    edges.push({ x1: w - ai, y1: 0, x2: w, y2: h });
+  } else if (right === "slope-right") {
+    edges.push({ x1: w, y1: 0, x2: w - ai, y2: h });
+  } else {
+    edges.push({ x1: w, y1: 0, x2: w, y2: h });
+  }
+
+  const handleClick = () => {
+    if (!isClickable) {
+      return;
+    }
+    hoverSound.onClick?.();
+    onClick();
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+    if (isClickable) {
+      hoverSound.onMouseEnter?.();
+    }
+  };
+
+  const cursorClass = isClickable ? "cursor-pointer" : "cursor-default";
+
+  return (
+    <button
+      ref={buttonRef}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => setIsHovered(false)}
+      className={`relative pointer-events-auto ${cursorClass} outline-none ${className}`}
+      style={{ width, height, ...extraStyle }}
+    >
+      <svg
+        className="absolute inset-0 w-full h-full"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+      >
+        <polygon
+          points={fillPoints}
+          fill={active ? "rgba(20,20,25,0.95)" : "rgba(10,10,15,0.95)"}
+        />
+        <line
+          x1={tl}
+          y1={0}
+          x2={tr}
+          y2={0}
+          stroke={active ? color : BORDER_COLOR}
+          strokeWidth="3"
+        />
+        {edges.map((e, i) => (
+          <line
+            key={i}
+            x1={e.x1}
+            y1={e.y1}
+            x2={e.x2}
+            y2={e.y2}
+            stroke={BORDER_COLOR}
+            strokeWidth="2"
+          />
+        ))}
+      </svg>
+      <div
+        className="relative z-10 h-full flex items-center justify-center px-4"
+        style={{ transform: contentOffsetX ? `translateX(${contentOffsetX}px)` : undefined }}
+      >
+        <span
+          className={`font-orbitron font-bold text-sm uppercase tracking-wider inline-flex items-center justify-center leading-none transition-colors duration-200 ${
+            active ? "text-white" : "text-white/80"
+          }`}
+        >
+          {children}
+        </span>
+      </div>
+    </button>
+  );
+};
+
+export default ParallelogramButton;

--- a/frontend/src/components/layout/panels/TopMenuBar.tsx
+++ b/frontend/src/components/layout/panels/TopMenuBar.tsx
@@ -22,9 +22,9 @@ import ProjectFundingPopover from "../../ui/popover/ProjectFundingPopover.tsx";
 import { GamePopover } from "../../ui/GamePopover";
 import { useHoverSound } from "@/hooks/useHoverSound.ts";
 import { HamburgerIcon, EyeIcon } from "../../ui/menuIcons.tsx";
+import ParallelogramButton, { ANGLE_INDENT, BUTTON_SPACING } from "./ParallelogramButton.tsx";
+import MilestoneAwardStatusStrip from "./MilestoneAwardStatusStrip.tsx";
 
-const ANGLE_INDENT = 20;
-const BUTTON_SPACING = 6;
 const BORDER_COLOR = "rgba(60,60,70,0.7)";
 const HAMBURGER_WIDTH = 65;
 const HAMBURGER_COLOR = "#ffffff";
@@ -46,121 +46,6 @@ const MilestoneAlertIndicator: React.FC<{ visible: boolean; top: number }> = ({ 
     </span>
   </div>
 );
-
-type EdgeStyle = "slope-left" | "slope-right" | "flat";
-
-interface ParallelogramButtonProps {
-  width: number;
-  height: number;
-  color: string;
-  children: React.ReactNode;
-  onClick: () => void;
-  buttonRef: React.RefObject<HTMLButtonElement | null>;
-  isActive?: boolean;
-  leftEdge?: EdgeStyle;
-  rightEdge?: EdgeStyle;
-  className?: string;
-  style?: React.CSSProperties;
-}
-
-const ParallelogramButton: React.FC<ParallelogramButtonProps> = ({
-  width,
-  height,
-  color,
-  children,
-  onClick,
-  buttonRef,
-  isActive = false,
-  leftEdge: left = "flat",
-  rightEdge: right = "flat",
-  className = "",
-  style: extraStyle,
-}) => {
-  const [isHovered, setIsHovered] = useState(false);
-  const hoverSound = useHoverSound();
-  const active = isHovered || isActive;
-
-  const ai = ANGLE_INDENT;
-  const w = width;
-  const h = height;
-
-  // slope-left (\): top indented, bottom at edge
-  // slope-right (/): top at edge, bottom indented
-  const tl = left === "slope-left" ? ai : 0;
-  const bl = left === "slope-right" ? ai : 0;
-  const tr = right === "slope-left" ? w - ai : w;
-  const br = right === "slope-right" ? w - ai : w;
-
-  const fillPoints = `${tl},0 ${tr},0 ${br},${h} ${bl},${h}`;
-
-  const edges: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
-  if (left === "slope-left") {
-    edges.push({ x1: ai, y1: 0, x2: 0, y2: h });
-  } else if (left === "slope-right") {
-    edges.push({ x1: 0, y1: 0, x2: ai, y2: h });
-  }
-  if (right === "slope-left") {
-    edges.push({ x1: w - ai, y1: 0, x2: w, y2: h });
-  } else if (right === "slope-right") {
-    edges.push({ x1: w, y1: 0, x2: w - ai, y2: h });
-  }
-
-  return (
-    <button
-      ref={buttonRef}
-      onClick={() => {
-        hoverSound.onClick?.();
-        onClick();
-      }}
-      onMouseEnter={() => {
-        setIsHovered(true);
-        hoverSound.onMouseEnter?.();
-      }}
-      onMouseLeave={() => setIsHovered(false)}
-      className={`relative pointer-events-auto cursor-pointer outline-none ${className}`}
-      style={{ width, height, ...extraStyle }}
-    >
-      <svg
-        className="absolute inset-0 w-full h-full"
-        viewBox={`0 0 ${w} ${h}`}
-        preserveAspectRatio="none"
-      >
-        <polygon
-          points={fillPoints}
-          fill={active ? "rgba(20,20,25,0.95)" : "rgba(10,10,15,0.95)"}
-        />
-        <line
-          x1={tl}
-          y1={0}
-          x2={tr}
-          y2={0}
-          stroke={active ? color : BORDER_COLOR}
-          strokeWidth="3"
-        />
-        {edges.map((e, i) => (
-          <line
-            key={i}
-            x1={e.x1}
-            y1={e.y1}
-            x2={e.x2}
-            y2={e.y2}
-            stroke={BORDER_COLOR}
-            strokeWidth="2"
-          />
-        ))}
-      </svg>
-      <div className="relative z-10 h-full flex items-center justify-center px-4">
-        <span
-          className={`font-orbitron font-bold text-sm uppercase tracking-wider transition-colors duration-200 ${
-            active ? "text-white" : "text-white/80"
-          }`}
-        >
-          {children}
-        </span>
-      </div>
-    </button>
-  );
-};
 
 const ENDGAME_ACCENT = "#3b82f6";
 
@@ -486,6 +371,17 @@ const TopMenuBar: React.FC<TopMenuBarProps> = ({
             </div>
           </div>
         </div>
+
+        {!isInitPhase && !isEndgame && (
+          <div
+            className={`absolute left-1/2 top-0 h-[60px] max-lg:h-[50px] flex items-center origin-top transition-opacity duration-500 ease-in-out ${
+              activePlanet === "solar-system" ? "opacity-0 pointer-events-none" : "opacity-100"
+            }`}
+            style={{ transform: `translateX(-50%) scale(${topBarScale})` }}
+          >
+            <MilestoneAwardStatusStrip />
+          </div>
+        )}
 
         <TravelPopover
           isVisible={showTravelPopover}

--- a/frontend/src/components/ui/display/AwardScoreboard.tsx
+++ b/frontend/src/components/ui/display/AwardScoreboard.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from "react";
+
+export interface ScoreboardPlayer {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface AwardScoreboardProps {
+  players: ScoreboardPlayer[];
+  playerProgress: { [playerId: string]: number };
+  className?: string;
+}
+
+const AwardScoreboard: React.FC<AwardScoreboardProps> = ({
+  players,
+  playerProgress,
+  className = "",
+}) => {
+  const sortedPlayers = useMemo(
+    () => [...players].sort((a, b) => (playerProgress[b.id] ?? 0) - (playerProgress[a.id] ?? 0)),
+    [players, playerProgress],
+  );
+
+  const longestNameLength = useMemo(
+    () => players.reduce((max, p) => Math.max(max, p.name.length), 0),
+    [players],
+  );
+
+  return (
+    <div
+      className={`flex-shrink-0 grid grid-cols-[auto_auto] gap-x-3 gap-y-1 ${className}`}
+      style={{ minWidth: `${longestNameLength + 5}ch` }}
+    >
+      {sortedPlayers.map((player) => {
+        const score = playerProgress[player.id] ?? 0;
+        return (
+          <React.Fragment key={player.id}>
+            <div className="flex items-center gap-2 text-sm">
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: player.color }}
+              />
+              <span className="text-white/80">{player.name}</span>
+            </div>
+            <span className="text-sm font-orbitron font-semibold text-white/50">{score}</span>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AwardScoreboard;

--- a/frontend/src/components/ui/display/DecorBoxTooltip.tsx
+++ b/frontend/src/components/ui/display/DecorBoxTooltip.tsx
@@ -9,6 +9,7 @@ interface DecorBoxTooltipProps {
   position: { x: number; y: number } | null;
   placement?: "below" | "above";
   cornerSize?: number;
+  maxWidth?: number | string;
 }
 
 const DecorBoxTooltip: React.FC<DecorBoxTooltipProps> = ({
@@ -17,6 +18,7 @@ const DecorBoxTooltip: React.FC<DecorBoxTooltipProps> = ({
   position,
   placement = "below",
   cornerSize = 14,
+  maxWidth,
 }) => {
   if ((!description && !children) || !position) return null;
 
@@ -25,12 +27,13 @@ const DecorBoxTooltip: React.FC<DecorBoxTooltipProps> = ({
 
   return createPortal(
     <div
-      className={`fixed w-max max-w-40 ${paddingClass} pointer-events-none animate-[fadeIn_150ms_ease-in]`}
+      className={`fixed w-max ${maxWidth === undefined ? "max-w-40" : ""} ${paddingClass} pointer-events-none animate-[fadeIn_150ms_ease-in]`}
       style={{
         left: position.x,
         top: position.y,
         transform: `translate(-50%, ${translateY})`,
         zIndex: Z_INDEX.LOADING_OVERLAY,
+        maxWidth,
       }}
     >
       <div

--- a/frontend/src/components/ui/popover/AwardPopover.tsx
+++ b/frontend/src/components/ui/popover/AwardPopover.tsx
@@ -12,6 +12,7 @@ import { canPerformActions } from "@/utils/actionUtils.ts";
 import { GamePopover, GamePopoverItem } from "../GamePopover";
 import { FormattedDescription } from "../display/FormattedDescription";
 import BehaviorSection from "../cards/BehaviorSection/BehaviorSection.tsx";
+import AwardScoreboard from "../display/AwardScoreboard.tsx";
 
 interface AwardPopoverProps {
   isVisible: boolean;
@@ -55,15 +56,6 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
           available: false,
           errors: [] as import("@/types/generated/api-types.ts").StateErrorDto[],
         }));
-
-  const longestNameLength = useMemo(() => {
-    if (!gameState) return 0;
-    const players = [
-      gameState.currentPlayer?.name ?? "",
-      ...gameState.otherPlayers.map((p) => p.name),
-    ];
-    return players.reduce((max, name) => Math.max(max, name.length), 0);
-  }, [gameState]);
 
   const allPlayers: PlayerInfo[] = useMemo(() => {
     if (!gameState) return [];
@@ -112,10 +104,6 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
           const globalData = globalAwards.find((a) => a.type === award.type);
           const styleColor = globalData?.style?.color ?? "#f39c12";
           const playerProgress = globalData?.playerProgress ?? {};
-
-          const sortedPlayers = [...allPlayers].sort(
-            (a, b) => (playerProgress[b.id] ?? 0) - (playerProgress[a.id] ?? 0),
-          );
 
           const getState = () => {
             if (isFunded) return "claimed" as const;
@@ -208,28 +196,7 @@ const AwardPopover: React.FC<AwardPopoverProps> = ({
                     </p>
                   </div>
 
-                  <div
-                    className="flex-shrink-0 grid grid-cols-[auto_auto] gap-x-3 gap-y-1"
-                    style={{ minWidth: `${longestNameLength + 5}ch` }}
-                  >
-                    {sortedPlayers.map((player) => {
-                      const score = playerProgress[player.id] ?? 0;
-                      return (
-                        <React.Fragment key={player.id}>
-                          <div className="flex items-center gap-2 text-sm">
-                            <span
-                              className="w-2 h-2 rounded-full flex-shrink-0"
-                              style={{ backgroundColor: player.color }}
-                            />
-                            <span className="text-white/80">{player.name}</span>
-                          </div>
-                          <span className="text-sm font-orbitron font-semibold text-white/50">
-                            {score}
-                          </span>
-                        </React.Fragment>
-                      );
-                    })}
-                  </div>
+                  <AwardScoreboard players={allPlayers} playerProgress={playerProgress} />
                 </div>
               </div>
             </GamePopoverItem>


### PR DESCRIPTION
### Frontend
- New `MilestoneAwardStatusStrip` mounted absolutely-centered in the top menu bar. Three milestone slots `\\ \\ \\` on the left, three award slots `/ / /` on the right; empty slots render faded so the layout is fixed and chips fill inside-out from the centre.
- Each filled chip is coloured with the owning player's colour, displays the milestone/award icon, and on hover opens a `DecorBoxTooltip` showing title, description, `Claimed/Funded by <player>` (right-aligned on the title row, player name in player colour), and — for awards — an `AwardScoreboard` of every player's progress.
- Inner-most chip uses a flat inner edge plus a slightly reduced width (`CHIP_WIDTH − 12`) to compensate for the missing slope, and the parallelogram content shifts toward the polygon centroid so the icon stays optically centred.

### Refactor
- Extracted `ParallelogramButton` out of `TopMenuBar.tsx` into its own module. `onClick` and `buttonRef` are now optional; chips render with `cursor-default` and skip hover sound when non-interactive. Added borders for `flat` edges, switched the inner span to `inline-flex items-center leading-none` (icon children now centre vertically in every existing call site too), and apply a centroid-based content translate so trapezoidal shapes don't look off-centre.
- Extracted the player-progress grid from `AwardPopover` into reusable `AwardScoreboard`. Re-used inside the new strip's award tooltip.
- `DecorBoxTooltip` gained an optional `maxWidth` prop; defaults to the existing `max-w-40` when omitted.

Closes #410