### PR TITLE
feat(backend): seedable deterministic RNG + reproducibility [Phase 5]

### DIFF
--- a/backend/internal/action/game/add_bot.go
+++ b/backend/internal/action/game/add_bot.go
@@ -3,7 +3,7 @@ package game
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	rand "math/rand/v2"
 	"time"
 
 	"github.com/google/uuid"
@@ -109,7 +109,7 @@ func (a *AddBotAction) Execute(ctx context.Context, gameID string, botName strin
 	}
 
 	if botName == "" {
-		botName = a.generateBotName(existingPlayers)
+		botName = a.generateBotName(g, existingPlayers)
 	}
 
 	botDifficulty := playerPkg.BotDifficulty(difficulty)
@@ -194,14 +194,19 @@ func (a *AddBotAction) runHealthCheck(gameID, botID, botName, difficulty, apiKey
 	}
 }
 
-func (a *AddBotAction) generateBotName(existingPlayers []*playerPkg.Player) string {
+// botNameRNGStream keeps deterministic bot-name selection independent of the deck
+// and setup RNG streams; offsetting by the current player count varies each bot.
+const botNameRNGStream uint64 = 0xB07
+
+func (a *AddBotAction) generateBotName(g *game.Game, existingPlayers []*playerPkg.Player) string {
 	taken := make(map[string]bool, len(existingPlayers))
 	for _, p := range existingPlayers {
 		taken[p.Name()] = true
 	}
 
-	// Shuffle and pick the first available name
-	perm := rand.Perm(len(botNames))
+	// Shuffle and pick the first available name (deterministic from the game Seed)
+	rng := rand.New(rand.NewPCG(g.Seed(), botNameRNGStream+uint64(len(existingPlayers))))
+	perm := rng.Perm(len(botNames))
 	for _, i := range perm {
 		if !taken[botNames[i]] {
 			return botNames[i]

--- a/backend/internal/action/game/create_game.go
+++ b/backend/internal/action/game/create_game.go
@@ -92,7 +92,10 @@ func (a *CreateGameAction) Execute(
 		return nil, err
 	}
 
-	log.Info("Game created", zap.String("game_id", gameID))
+	// Log the master RNG seed so a reported game can be reproduced deterministically
+	// (seed + action sequence) via the replay harness. Kept out of the client DTO on
+	// purpose: exposing it would let players predict the deck shuffle.
+	log.Info("Game created", zap.String("game_id", gameID), zap.Uint64("seed", newGame.Seed()))
 	return newGame, nil
 }
 

--- a/backend/internal/action/turn_management/start_game.go
+++ b/backend/internal/action/turn_management/start_game.go
@@ -3,8 +3,7 @@ package turn_management
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"time"
+	rand "math/rand/v2"
 
 	"go.uber.org/zap"
 
@@ -94,7 +93,7 @@ func (a *StartGameAction) Execute(ctx context.Context, gameID string, playerID s
 	for i, p := range players {
 		playerIDs[i] = p.ID()
 	}
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rng := g.SetupRand()
 	rng.Shuffle(len(playerIDs), func(i, j int) {
 		playerIDs[i], playerIDs[j] = playerIDs[j], playerIDs[i]
 	})

--- a/backend/internal/cards/registry.go
+++ b/backend/internal/cards/registry.go
@@ -20,17 +20,23 @@ type CardRegistry interface {
 // InMemoryCardRegistry implements CardRegistry with an in-memory map
 type InMemoryCardRegistry struct {
 	cards map[string]gamecards.Card
+	order []string // preserves load (JSON) order so GetAll is deterministic
 }
 
 // NewInMemoryCardRegistry creates a new card registry from a slice of cards
 func NewInMemoryCardRegistry(cardList []gamecards.Card) *InMemoryCardRegistry {
 	cardMap := make(map[string]gamecards.Card, len(cardList))
+	order := make([]string, 0, len(cardList))
 	for _, card := range cardList {
+		if _, exists := cardMap[card.ID]; !exists {
+			order = append(order, card.ID)
+		}
 		cardMap[card.ID] = card
 	}
 
 	return &InMemoryCardRegistry{
 		cards: cardMap,
+		order: order,
 	}
 }
 
@@ -46,11 +52,12 @@ func (r *InMemoryCardRegistry) GetByID(cardID string) (*gamecards.Card, error) {
 	return &cardCopy, nil
 }
 
-// GetAll returns all cards in the registry
+// GetAll returns all cards in the registry, in their original load (JSON) order
+// so that deck construction is deterministic for a given seed.
 func (r *InMemoryCardRegistry) GetAll() []gamecards.Card {
-	cardList := make([]gamecards.Card, 0, len(r.cards))
-	for _, card := range r.cards {
-		cardList = append(cardList, card.DeepCopy())
+	cardList := make([]gamecards.Card, 0, len(r.order))
+	for _, id := range r.order {
+		cardList = append(cardList, r.cards[id].DeepCopy())
 	}
 	return cardList
 }

--- a/backend/internal/game/colony/registry.go
+++ b/backend/internal/game/colony/registry.go
@@ -13,15 +13,20 @@ type ColonyRegistry interface {
 // InMemoryColonyRegistry implements ColonyRegistry with an in-memory map
 type InMemoryColonyRegistry struct {
 	colonies map[string]ColonyDefinition
+	order    []string // preserves load (JSON) order so GetAll is deterministic
 }
 
 // NewInMemoryColonyRegistry creates a new colony registry from a slice of definitions
 func NewInMemoryColonyRegistry(colonyList []ColonyDefinition) *InMemoryColonyRegistry {
 	colonyMap := make(map[string]ColonyDefinition, len(colonyList))
+	order := make([]string, 0, len(colonyList))
 	for _, c := range colonyList {
+		if _, exists := colonyMap[c.ID]; !exists {
+			order = append(order, c.ID)
+		}
 		colonyMap[c.ID] = c
 	}
-	return &InMemoryColonyRegistry{colonies: colonyMap}
+	return &InMemoryColonyRegistry{colonies: colonyMap, order: order}
 }
 
 // GetByID retrieves a colony tile definition by ID
@@ -33,11 +38,12 @@ func (r *InMemoryColonyRegistry) GetByID(colonyID string) (*ColonyDefinition, er
 	return &c, nil
 }
 
-// GetAll returns all colony tile definitions
+// GetAll returns all colony tile definitions in their original load (JSON) order
+// so that seeded colony selection is reproducible for a given seed.
 func (r *InMemoryColonyRegistry) GetAll() []ColonyDefinition {
-	result := make([]ColonyDefinition, 0, len(r.colonies))
-	for _, c := range r.colonies {
-		result = append(result, c)
+	result := make([]ColonyDefinition, 0, len(r.order))
+	for _, id := range r.order {
+		result = append(result, r.colonies[id])
 	}
 	return result
 }

--- a/backend/internal/game/datastore/game_state.go
+++ b/backend/internal/game/datastore/game_state.go
@@ -18,6 +18,11 @@ type GameState struct {
 	Settings     shared.GameSettings
 	HostPlayerID string
 
+	// Seed is the master RNG seed for this game. All randomness (deck shuffles,
+	// turn order, milestone/award/colony selection) is derived deterministically
+	// from it, so a game can be reproduced from (Seed + the sequence of actions).
+	Seed uint64
+
 	CurrentPhase shared.GamePhase
 	Generation   int
 

--- a/backend/internal/game/deck/deck.go
+++ b/backend/internal/game/deck/deck.go
@@ -3,7 +3,7 @@ package deck
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	rand "math/rand/v2"
 
 	"go.uber.org/zap"
 
@@ -11,23 +11,30 @@ import (
 	"terraforming-mars-backend/internal/logger"
 )
 
+// deckRNGStream separates deck randomness from other per-game RNG streams. The
+// initial shuffle uses the base stream; each reshuffle offsets by ShuffleCount so
+// successive reshuffles of the same game produce distinct, reproducible orders.
+const deckRNGStream uint64 = 0xDECC00
+
 type Deck struct {
 	ds     *datastore.DataStore
 	gameID string
 }
 
-func NewDeck(ds *datastore.DataStore, gameID string, projectCardIDs, corpIDs, preludeIDs []string) *Deck {
+func NewDeck(ds *datastore.DataStore, gameID string, seed uint64, projectCardIDs, corpIDs, preludeIDs []string) *Deck {
+	rng := rand.New(rand.NewPCG(seed, deckRNGStream))
+
 	projectCopy := make([]string, len(projectCardIDs))
 	copy(projectCopy, projectCardIDs)
-	rand.Shuffle(len(projectCopy), func(i, j int) { projectCopy[i], projectCopy[j] = projectCopy[j], projectCopy[i] })
+	rng.Shuffle(len(projectCopy), func(i, j int) { projectCopy[i], projectCopy[j] = projectCopy[j], projectCopy[i] })
 
 	corpCopy := make([]string, len(corpIDs))
 	copy(corpCopy, corpIDs)
-	rand.Shuffle(len(corpCopy), func(i, j int) { corpCopy[i], corpCopy[j] = corpCopy[j], corpCopy[i] })
+	rng.Shuffle(len(corpCopy), func(i, j int) { corpCopy[i], corpCopy[j] = corpCopy[j], corpCopy[i] })
 
 	preludeCopy := make([]string, len(preludeIDs))
 	copy(preludeCopy, preludeIDs)
-	rand.Shuffle(len(preludeCopy), func(i, j int) { preludeCopy[i], preludeCopy[j] = preludeCopy[j], preludeCopy[i] })
+	rng.Shuffle(len(preludeCopy), func(i, j int) { preludeCopy[i], preludeCopy[j] = preludeCopy[j], preludeCopy[i] })
 
 	if err := ds.UpdateGame(gameID, func(s *datastore.GameState) {
 		s.ProjectCards = projectCopy
@@ -248,7 +255,10 @@ func (d *Deck) Remove(ctx context.Context, cardIDs []string) error {
 
 func shuffleDeck(s *datastore.GameState) {
 	s.ProjectCards = append(s.ProjectCards, s.DiscardPile...)
-	rand.Shuffle(len(s.ProjectCards), func(i, j int) { s.ProjectCards[i], s.ProjectCards[j] = s.ProjectCards[j], s.ProjectCards[i] })
+	// Offset the stream past the initial shuffle (+1) and per reshuffle so each
+	// reshuffle draws an independent, reproducible order from the same game Seed.
+	rng := rand.New(rand.NewPCG(s.Seed, deckRNGStream+1+uint64(s.ShuffleCount)))
+	rng.Shuffle(len(s.ProjectCards), func(i, j int) { s.ProjectCards[i], s.ProjectCards[j] = s.ProjectCards[j], s.ProjectCards[i] })
 	s.DiscardPile = make([]string, 0)
 	s.ShuffleCount++
 }

--- a/backend/internal/game/game.go
+++ b/backend/internal/game/game.go
@@ -3,6 +3,7 @@ package game
 import (
 	"context"
 	"fmt"
+	mathrand "math/rand/v2"
 	"slices"
 	"strings"
 	"sync"
@@ -262,6 +263,7 @@ func NewGame(
 		SelectPreludeCardsPhases:   make(map[string]*shared.SelectPreludeCardsPhase),
 		DeferredStartingChoices:    make(map[string]*shared.DeferredStartingChoices),
 		TradeFleets:                make(map[string]bool),
+		Seed:                       mathrand.Uint64(),
 	}
 
 	// Insert state into DataStore so components can read/write through it
@@ -295,6 +297,32 @@ func NewGame(
 // ID returns the game ID
 func (g *Game) ID() string {
 	return g.id
+}
+
+// RNG stream identifiers. Each purpose derives an independent deterministic stream
+// from the game Seed so that adding a draw in one area does not perturb another.
+const (
+	rngStreamSetup uint64 = 0x5E7079 // turn order, colony + milestone/award selection
+	rngStreamDeck  uint64 = 0xDECC00 // deck shuffles (offset by ShuffleCount per reshuffle)
+)
+
+// Seed returns the master RNG seed for this game.
+func (g *Game) Seed() uint64 {
+	var seed uint64
+	g.read(func(s *datastore.GameState) { seed = s.Seed })
+	return seed
+}
+
+// SetSeed overrides the master RNG seed. Must be called before InitDeck / StartGame
+// (e.g. by the replay harness) for the override to take effect on setup randomness.
+func (g *Game) SetSeed(seed uint64) {
+	g.update(func(s *datastore.GameState) { s.Seed = seed })
+}
+
+// SetupRand returns a deterministic RNG for one-time game setup (turn order,
+// colony and milestone/award selection), derived from the game Seed.
+func (g *Game) SetupRand() *mathrand.Rand {
+	return mathrand.New(mathrand.NewPCG(g.Seed(), rngStreamSetup))
 }
 
 func (g *Game) CreatedAt() time.Time {
@@ -418,7 +446,7 @@ func (g *Game) SetDeck(d *deck.Deck) {
 func (g *Game) InitDeck(projectCardIDs, corpIDs, preludeIDs []string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.deck = deck.NewDeck(g.ds, g.id, projectCardIDs, corpIDs, preludeIDs)
+	g.deck = deck.NewDeck(g.ds, g.id, g.Seed(), projectCardIDs, corpIDs, preludeIDs)
 	g.update(func(s *datastore.GameState) { s.UpdatedAt = time.Now() })
 }
 

--- a/backend/test/action/deck_recycling_test.go
+++ b/backend/test/action/deck_recycling_test.go
@@ -187,7 +187,7 @@ func TestDeckRecycling_AutoShuffleOnEmptyDrawPile(t *testing.T) {
 
 	// Create a deck with only 2 project cards in draw pile
 	ds := testutil.NewTestDataStoreWithGame(t, "test-game")
-	gameDeck := deck.NewDeck(ds, "test-game", []string{"card-a", "card-b"}, nil, nil)
+	gameDeck := deck.NewDeck(ds, "test-game", 42, []string{"card-a", "card-b"}, nil, nil)
 
 	// Draw all cards to empty the draw pile
 	drawn, err := gameDeck.DrawProjectCards(ctx, 2)
@@ -215,7 +215,7 @@ func TestDeckRecycling_PreludeCardsNeverReshuffledIntoProjectDeck(t *testing.T) 
 	projectCards := []string{"card-a", "card-b"}
 	preludeCards := []string{"P01", "P02", "P03", "P04"}
 	ds2 := testutil.NewTestDataStoreWithGame(t, "test-game")
-	gameDeck := deck.NewDeck(ds2, "test-game", projectCards, nil, preludeCards)
+	gameDeck := deck.NewDeck(ds2, "test-game", 42, projectCards, nil, preludeCards)
 
 	// Draw all project cards to empty the draw pile
 	drawn, err := gameDeck.DrawProjectCards(ctx, 2)
@@ -250,7 +250,7 @@ func TestDeckRecycling_AutoShuffleFailsWhenBothPilesEmpty(t *testing.T) {
 
 	// Create a deck with only 1 project card
 	ds3 := testutil.NewTestDataStoreWithGame(t, "test-game")
-	gameDeck := deck.NewDeck(ds3, "test-game", []string{"card-a"}, nil, nil)
+	gameDeck := deck.NewDeck(ds3, "test-game", 42, []string{"card-a"}, nil, nil)
 
 	// Draw the only card
 	_, err := gameDeck.DrawProjectCards(ctx, 1)
@@ -271,7 +271,7 @@ func TestDeckRecycling_RealDeckNeverDealsPreludeOrCorporation(t *testing.T) {
 	testutil.AssertTrue(t, len(corpIDs) > 0, "should have corporation cards")
 
 	ds4 := testutil.NewTestDataStoreWithGame(t, "test-game")
-	gameDeck := deck.NewDeck(ds4, "test-game", projectCardIDs, corpIDs, preludeIDs)
+	gameDeck := deck.NewDeck(ds4, "test-game", 42, projectCardIDs, corpIDs, preludeIDs)
 
 	// Build lookup sets for non-project card types
 	preludeSet := make(map[string]bool, len(preludeIDs))

--- a/backend/test/game/determinism_test.go
+++ b/backend/test/game/determinism_test.go
@@ -1,0 +1,58 @@
+package game_test
+
+import (
+	"slices"
+	"testing"
+
+	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
+	"terraforming-mars-backend/internal/game/shared"
+	"terraforming-mars-backend/test/testutil"
+)
+
+// buildSeededGame reproduces a game from a seed via the replay primitive (which uses
+// the production deck-construction path) and returns the shuffled project-card order.
+func buildSeededGame(t *testing.T, seed uint64) []string {
+	t.Helper()
+	g, _, _ := testutil.NewSeededGame(t, seed, shared.GameSettings{})
+	return g.Deck().ProjectCards()
+}
+
+func TestDeckShuffle_SameSeedIsReproducible(t *testing.T) {
+	const seed uint64 = 0xC0FFEE
+
+	first := buildSeededGame(t, seed)
+	second := buildSeededGame(t, seed)
+
+	if len(first) == 0 {
+		t.Fatal("expected a non-empty project deck")
+	}
+	if !slices.Equal(first, second) {
+		t.Fatalf("same seed produced different deck orders:\n first[:5]=%v\nsecond[:5]=%v",
+			first[:min(5, len(first))], second[:min(5, len(second))])
+	}
+}
+
+func TestDeckShuffle_DifferentSeedsDiffer(t *testing.T) {
+	a := buildSeededGame(t, 1)
+	b := buildSeededGame(t, 2)
+
+	if slices.Equal(a, b) {
+		t.Fatal("different seeds produced identical deck orders (RNG not seed-dependent)")
+	}
+}
+
+// TestSetupRand_SameSeedIsReproducible guards the setup RNG stream (turn order,
+// milestone/award/colony selection) used by StartGameAction.
+func TestSetupRand_SameSeedIsReproducible(t *testing.T) {
+	repo := testutil.NewTestGameRepository(t)
+	settings := shared.GameSettings{MaxPlayers: 4}
+	mk := func() []int {
+		g := game.NewGame(repo.DataStore(), "setup-test", "", settings, board.GenerateMarsBoard(false))
+		g.SetSeed(42)
+		return g.SetupRand().Perm(10)
+	}
+	if !slices.Equal(mk(), mk()) {
+		t.Fatal("SetupRand with the same seed produced different sequences")
+	}
+}

--- a/backend/test/game/determinism_test.go
+++ b/backend/test/game/determinism_test.go
@@ -6,6 +6,7 @@ import (
 
 	"terraforming-mars-backend/internal/game"
 	"terraforming-mars-backend/internal/game/board"
+	"terraforming-mars-backend/internal/game/colony"
 	"terraforming-mars-backend/internal/game/shared"
 	"terraforming-mars-backend/test/testutil"
 )
@@ -54,5 +55,67 @@ func TestSetupRand_SameSeedIsReproducible(t *testing.T) {
 	}
 	if !slices.Equal(mk(), mk()) {
 		t.Fatal("SetupRand with the same seed produced different sequences")
+	}
+}
+
+// colonyIDs builds a registry from a fixed input order and returns GetAll's IDs.
+func colonyIDs(reg colony.ColonyRegistry) []string {
+	all := reg.GetAll()
+	ids := make([]string, len(all))
+	for i, c := range all {
+		ids[i] = c.ID
+	}
+	return ids
+}
+
+// TestColonyRegistry_GetAllPreservesOrder guards the root cause of the colony
+// non-determinism: GetAll must return definitions in a stable load order, not
+// in Go's randomized map-iteration order. Without a stable order, the seeded
+// shuffle in StartGameAction.initializeColonies picks different colonies each
+// run even for a fixed seed.
+func TestColonyRegistry_GetAllPreservesOrder(t *testing.T) {
+	input := []colony.ColonyDefinition{
+		{ID: "luna"}, {ID: "triton"}, {ID: "ceres"}, {ID: "enceladus"},
+		{ID: "io"}, {ID: "titan"}, {ID: "callisto"}, {ID: "ganymede"},
+	}
+	want := []string{"luna", "triton", "ceres", "enceladus", "io", "titan", "callisto", "ganymede"}
+
+	// Every construction must yield the exact input order (map iteration would
+	// vary run-to-run, so repeating catches the regression probabilistically).
+	for i := 0; i < 20; i++ {
+		reg := colony.NewInMemoryColonyRegistry(input)
+		if got := colonyIDs(reg); !slices.Equal(got, want) {
+			t.Fatalf("GetAll did not preserve load order (iteration %d): got %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestColonySelection_SameSeedIsReproducible exercises the real selection path
+// (registry GetAll shuffled by the seed-derived SetupRand) and asserts a fixed
+// seed reproduces the same picks while different seeds diverge.
+func TestColonySelection_SameSeedIsReproducible(t *testing.T) {
+	input := []colony.ColonyDefinition{
+		{ID: "luna"}, {ID: "triton"}, {ID: "ceres"}, {ID: "enceladus"},
+		{ID: "io"}, {ID: "titan"}, {ID: "callisto"}, {ID: "ganymede"},
+	}
+	repo := testutil.NewTestGameRepository(t)
+	settings := shared.GameSettings{MaxPlayers: 4}
+
+	// selectWithSeed mirrors StartGameAction.initializeColonies: shuffle GetAll
+	// with the game's SetupRand, then take the first 5.
+	selectWithSeed := func(seed uint64) []string {
+		g := game.NewGame(repo.DataStore(), "colony-test", "", settings, board.GenerateMarsBoard(false))
+		g.SetSeed(seed)
+		rng := g.SetupRand()
+		ids := colonyIDs(colony.NewInMemoryColonyRegistry(input))
+		rng.Shuffle(len(ids), func(i, j int) { ids[i], ids[j] = ids[j], ids[i] })
+		return ids[:5]
+	}
+
+	if !slices.Equal(selectWithSeed(0xC0FFEE), selectWithSeed(0xC0FFEE)) {
+		t.Fatal("same seed produced different colony selections")
+	}
+	if slices.Equal(selectWithSeed(1), selectWithSeed(2)) {
+		t.Fatal("different seeds produced identical colony selections (selection not seed-dependent)")
 	}
 }

--- a/backend/test/testutil/game_helpers.go
+++ b/backend/test/testutil/game_helpers.go
@@ -2,14 +2,46 @@ package testutil
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"terraforming-mars-backend/internal/action"
 	"terraforming-mars-backend/internal/cards"
 	"terraforming-mars-backend/internal/game"
+	"terraforming-mars-backend/internal/game/board"
 	"terraforming-mars-backend/internal/game/player"
 	"terraforming-mars-backend/internal/game/shared"
 )
+
+// NewSeededGame builds a game with a fixed master RNG seed and an initialized deck,
+// using the same deck-construction path as production (GetCardIDsByPacks -> InitDeck).
+// Because all game randomness derives from the seed, this is the replay primitive for
+// reproducing a reported game: the server logs each game's seed at creation, so a bug
+// report's seed can be replayed here to reconstruct the identical deck deterministically.
+func NewSeededGame(t *testing.T, seed uint64, settings shared.GameSettings) (*game.Game, game.GameRepository, cards.CardRegistry) {
+	t.Helper()
+
+	repo := NewTestGameRepository(t)
+	cardRegistry := CreateTestCardRegistry()
+	if len(settings.CardPacks) == 0 {
+		settings.CardPacks = []string{"base-game"}
+	}
+	if settings.MaxPlayers == 0 {
+		settings.MaxPlayers = 4
+	}
+
+	g := game.NewGame(repo.DataStore(), "seeded-"+strconv.FormatUint(seed, 10), "", settings, board.GenerateMarsBoard(false))
+	g.SetSeed(seed) // override the auto-generated seed before the deck is shuffled
+
+	projectCards, corpCards, preludeCards := cards.GetCardIDsByPacks(cardRegistry, settings.CardPacks)
+	g.InitDeck(projectCards, corpCards, preludeCards)
+	g.SetVPCardLookup(cards.NewVPCardLookupAdapter(cardRegistry))
+
+	if err := repo.Create(context.Background(), g); err != nil {
+		t.Fatalf("Failed to create seeded game: %v", err)
+	}
+	return g, repo, cardRegistry
+}
 
 // StartTestGame transitions a game from lobby to active status
 func StartTestGame(t *testing.T, g *game.Game) {


### PR DESCRIPTION
## Phase 5 — determinism + replay foundation

Stacked on **Phase 1** (#575). Makes game randomness reproducible so a reported game can be replayed deterministically — the backbone of easy end-to-end bug reproduction.

### Changes
- **Master `Seed`** added to `GameState`, auto-generated at `NewGame` via `math/rand/v2`, overridable with `Game.SetSeed` before setup (for replay). `Game.SetupRand()` + a deck stream derive **independent per-purpose sequences** so a draw in one area can't perturb another.
- **Migrated all randomness** off the process-global `math/rand` v1 to seed-derived `math/rand/v2`: deck shuffle + reshuffle, turn order, colony + milestone/award selection, bot-name pick.
- **Fixed a real reproducibility bug**: `InMemoryCardRegistry.GetAll()` iterated a map (non-deterministic deck input); now preserves JSON load order, so a fixed seed reproduces the exact deck through the production `GetCardIDsByPacks → InitDeck` path.
- **Seed logged at creation** so a reported game is reproducible from `(seed + actions)`. **Not** exposed in the client `GameDto` on purpose — that would let players predict the shuffle.
- **Replay primitive** `testutil.NewSeededGame` + determinism tests (same-seed reproducible, different-seed divergent) for both deck and setup RNG.

### Verification (honest, exit-code-checked)
- `go build ./...` → exit 0
- `golangci-lint run ./...` → 0 issues
- `go test ./test/...` → 26 packages, 0 failures (incl. the integration create→join→start lifecycle)
- Server binary boots and fully initializes all registries/handlers (live HTTP smoke on :3001 blocked only by an unrelated local service already bound to that port).

Base is the Phase 1 branch (stacked). Rebases onto `main` once #574/#575 land.

https://claude.ai/code/session_013msNSU7W6N1EKzjcoZVH2Y